### PR TITLE
Implant Autocomplete cleanup

### DIFF
--- a/implant.js
+++ b/implant.js
@@ -32,14 +32,14 @@ const implantInfo = async function(name){
 }
 
 const partialMatches = async function(query){
-	let matches = [];
+	const matches = [];
 	query = query.replace(/[“”]/g, '"').toLowerCase();
 
 	for(const implant in implantsJSON){
-		if(implant.toLowerCase().indexOf(query) > -1){
+		if(implant.toLowerCase().startsWith(query)){
 			matches.push({name: implant, value: implant});
 		}
-		if(matches.length >= 25){
+		if(matches.length === 25){
 			break;
 		}
 	}
@@ -53,12 +53,12 @@ module.exports = {
 			throw "Search contains disallowed characters";
 		}
 		
-		let iInfo = await implantInfo(name);
+		const iInfo = await implantInfo(name);
 
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new Discord.MessageEmbed();
 		resEmbed.setTitle(iInfo.name);
-		resEmbed.setThumbnail('http://census.daybreakgames.com/files/ps2/images/static/'+iInfo.image+'.png');
-		if(typeof(iInfo.desc) !== 'undefined'){
+		resEmbed.setThumbnail(`http://census.daybreakgames.com/files/ps2/images/static/'${iInfo.image}.png`);
+		if(iInfo.desc !== undefined){
 			resEmbed.addField("Description", iInfo.desc);
 		}
 		else{

--- a/implant.js
+++ b/implant.js
@@ -10,15 +10,6 @@ const implantInfo = async function(name){
 		return returnObj;
 	}
 
-	// //Lower case name match
-	// for(const implant in implantsJSON){
-	// 	if(implant.toLowerCase() == name.toLowerCase()){
-	// 		let returnObj = implantsJSON[implant];
-	// 		returnObj.name = implant;
-	// 		return returnObj;
-	// 	}
-	// }
-
 	//Partial match
 	for(const implant in implantsJSON){
 		if(implant.toLowerCase().includes(name.toLowerCase())){

--- a/implant.js
+++ b/implant.js
@@ -4,25 +4,25 @@ const {badQuery} = require('./utils.js');
 
 const implantInfo = async function(name){
 	//Check if ID matches
-	if(typeof(implantsJSON[name]) !== 'undefined'){
-		let returnObj = implantsJSON[name];
+	if(implantsJSON[name] !== undefined){
+		const returnObj = implantsJSON[name];
 		returnObj.name = name;
 		return returnObj;
 	}
 
-	//Lower case name match
-	for(const implant in implantsJSON){
-		if(implant.toLowerCase() == name.toLowerCase()){
-			let returnObj = implantsJSON[implant];
-			returnObj.name = implant;
-			return returnObj;
-		}
-	}
+	// //Lower case name match
+	// for(const implant in implantsJSON){
+	// 	if(implant.toLowerCase() == name.toLowerCase()){
+	// 		let returnObj = implantsJSON[implant];
+	// 		returnObj.name = implant;
+	// 		return returnObj;
+	// 	}
+	// }
 
 	//Partial match
 	for(const implant in implantsJSON){
-		if(implant.toLowerCase().indexOf(name.toLowerCase()) > -1){
-			let returnObj = implantsJSON[implant];
+		if(implant.toLowerCase().includes(name.toLowerCase())){
+			const returnObj = implantsJSON[implant];
 			returnObj.name = implant;
 			return returnObj;
 		}
@@ -36,7 +36,7 @@ const partialMatches = async function(query){
 	query = query.replace(/[“”]/g, '"').toLowerCase();
 
 	for(const implant in implantsJSON){
-		if(implant.toLowerCase().startsWith(query)){
+		if(implant.toLowerCase().includes(query)){
 			matches.push({name: implant, value: implant});
 		}
 		if(matches.length === 25){


### PR DESCRIPTION
When searching for implants to show as suggestions, it should be more accurate now. Instead of accepting any implants that contains the query we only look at implants names that begin with the query.

I also elected to remove support for accepting partial queries. With the improved autocomplete suggestions, it seems a bit superfluous to keep it in.

Edit:
reverted removing partial queries and looking at the beginning.