### PR TITLE
Twitter Listener Backend Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The bot is designed to be simple to use.  Once added to your server with the [in
 
 ## Self hosting
 
-If you would like to deploy your own version of the bot, it is designed to run on [Heroku](https://www.heroku.com/home).  When running locally a `.env` file is used for the environment variables, including the [Discord Token](https://discordapp.com/developers/applications/me), [Daybreak Census API service ID](https://census.daybreakgames.com/), Postgres URL (optional), and [Twitter API credentials (optional)](https://developer.twitter.com/en/portal/dashboard).  Subscription functionality will be disabled if a database URL is not present. To use the Twitter API, you must have a Postgres URL.
+If you would like to deploy your own version of the bot, it is designed to run on [Heroku](https://www.heroku.com/home).  When running locally a `.env` file is used for the environment variables, including the [Discord Token](https://discordapp.com/developers/applications/me), [Daybreak Census API service ID](https://census.daybreakgames.com/), Postgres URL (optional), and [Twitter API credentials (optional)](https://developer.twitter.com/en/portal/dashboard).  Subscription functionality will be disabled if a database URL is not present. To use the Twitter API, you must have a Postgres URL. To ensure `latestTweet()` in `twitterListener.js` works properly on first time setup, manually modify the insert queries in `dbStructure.sql` to insert the lastest tweet id's for tracked users.
 
 Your `.env` file should look something like this
 

--- a/dbStructure.sql
+++ b/dbStructure.sql
@@ -27,6 +27,12 @@ CREATE TABLE IF NOT EXISTS news(
 	source TEXT
 );
 
+CREATE TABLE IF NOT EXISTS latestTweets(
+	userid TEXT,
+	username TEXT,
+	tweetid TEXT
+);
+
 CREATE TABLE IF NOT EXISTS alertmaintenance(
 	alertid TEXT NOT NULL,
 	messageid TEXT PRIMARY KEY NOT NULL,
@@ -121,3 +127,6 @@ INSERT INTO opencontinents (world) VALUES ('jaeger');
 INSERT INTO opencontinents (world) VALUES ('soltech');
 INSERT INTO opencontinents (world) VALUES ('genudine');
 INSERT INTO opencontinents (world) VALUES ('ceres');
+
+INSERT INTO latestTweets (userID, username) VALUES ('829358606', 'WrelPlays');
+INSERT INTO latestTweets (userID, username) VALUES ('247430686', 'planetside2');

--- a/dbStructure.sql
+++ b/dbStructure.sql
@@ -128,5 +128,6 @@ INSERT INTO opencontinents (world) VALUES ('soltech');
 INSERT INTO opencontinents (world) VALUES ('genudine');
 INSERT INTO opencontinents (world) VALUES ('ceres');
 
-INSERT INTO latestTweets (userID, username) VALUES ('829358606', 'WrelPlays');
-INSERT INTO latestTweets (userID, username) VALUES ('247430686', 'planetside2');
+-- Manually insert the latest tweetid from tracked users for latestTweets() in twitterListener.js
+-- INSERT INTO latestTweets (userID, username) VALUES ('829358606', 'WrelPlays');
+-- INSERT INTO latestTweets (userID, username) VALUES ('247430686', 'planetside2');

--- a/main.js
+++ b/main.js
@@ -92,6 +92,7 @@ client.on('ready', async () => {
 		if(twitterAvail){
 			twitterListener.init();
 			twitterListener.connect(SQLclient, client.channels);
+			twitterListener.latestTweet(SQLclient, client.channels);
 		}
 		outfitMaintenance.update(SQLclient);
 		alertMaintenance.update(SQLclient, client);

--- a/twitterListener.js
+++ b/twitterListener.js
@@ -115,7 +115,7 @@ async function postMessage(SQLclient, channels, jsonObj){
 	
 	const url = `https://twitter.com/${tag}/status/${jsonObj.data.id}`;
 	const result = await SQLclient.query('SELECT * FROM news WHERE source = $1', [`${tag}-twitter`]);
-	for(const row of result.rows){
+	result.rows.forEach(async (row) => {
 		try {
 			const resChann = await channels.fetch(row.channel);
 			if (resChann.type === 'DM'){
@@ -138,7 +138,7 @@ async function postMessage(SQLclient, channels, jsonObj){
 				console.log(error);
 			}
 		}
-	}
+	});
 }
 
 module.exports = {

--- a/twitterListener.js
+++ b/twitterListener.js
@@ -14,137 +14,86 @@ const {default: got} = require('got');
 const messageHandler = require('./messageHandler.js');
 const subscriptions = require('./subscriptions.js');
 
-const token = process.env.TWITTER_BEARER_TOKEN;  
+const token = process.env.TWITTER_BEARER_TOKEN;
 
-const rulesURL = 'https://api.twitter.com/2/tweets/search/stream/rules'
-const streamURL = 'https://api.twitter.com/2/tweets/search/stream?&user.fields=username&tweet.fields=in_reply_to_user_id&expansions=referenced_tweets.id,author_id';
+const rulesURL = 'https://api.twitter.com/2/tweets/search/stream/rules';
 
-// Edit rules as desired here below
-const rules = [
-	{ 'value': 'from:822515900', 'tag': 'Remain_NA' },
-	{ 'value': 'from:829358606', 'tag': 'WrelPlays' },
-	{ 'value': 'from:247430686', 'tag': 'planetside2' },
-  ];
 
 /**
- * Get the rules currently set in the Twitter API.
- * @returns An array of objects containing the rules that are currently set
+ * Get the rules currently set in the Twitter stream API.
+ * @returns {Promise<any>} An array of objects containing the rules that are currently set
  */
 async function getAllRules() {
-
-    const response = await got(rulesURL, { headers: {
-        "authorization": `Bearer ${token}`
+	const response = await got(rulesURL, { headers: {
+		"authorization": `Bearer ${token}`
     }});
-
+	
     if (response.statusCode !== 200) {
-        throw response.body;
+		throw response.body;
     }
-
+	
     return response.body;
 }
 
 /**
- * Delete currently set rules.
- * @param rules - An array of objects containing the rules that are currently set
- * @returns the response from the Twitter API
+ * Delete currently set rules in Twitter stream API.
+ * @param {{data: any[], id: string}} rules - An array of objects containing the rules that are currently set
  */
 async function deleteAllRules(rules) {
-
-    if (!Array.isArray(rules.data)) {
-        return;
+	
+	if (!Array.isArray(rules.data)) {
+		return;
     }
-
+	
     const ids = rules.data.map(rule => rule.id);
-
+	
     const data = {
-        "delete": {
-            "ids": ids
+		"delete": {
+			"ids": ids
         }
     };
-
+	
     const response = await got(rulesURL, {json: data, headers: {
-        "content-type": "application/json",
+		"content-type": "application/json",
         "authorization": `Bearer ${token}`
     }});
-
+	
     if (response.statusCode !== 200) {
-        throw new Error(response.body);
+		throw new Error(response.body);
     }
-    
-    return (response.body);
 }
 
 /**
- * set the rules in the Twitter API.
- * @returns The response from the Twitter API
+ * Set the rules for the Twitter stream API.
  */
 async function setRules() {
-
-    const data = {
-        "add": rules
-      };
-
+	// Edit rules as desired here below
+	const rules = [
+		{ 'value': 'from:822515900', 'tag': 'Remain_NA' },
+		{ 'value': 'from:829358606', 'tag': 'WrelPlays' },
+		{ 'value': 'from:247430686', 'tag': 'planetside2' },
+	];
+	
+	const data = {
+		"add": rules
+	};
+	
 	const response = await got.post( rulesURL, {json: data, headers: {
-        "content-type": "application/json",
+		"content-type": "application/json",
         "authorization": `Bearer ${token}`
     }});
-
-    if (response.statusCode !== 201) {
-        throw new Error(response.body);
-    }
-    
-    return (response.body);
-}
-
-/**
- * Connect to the Twitter API stream and send new tweets to subscribed discord channels
- * @param {string} token - The bearer token for the Twitter API
- * @param {pg.Client} SQLclient - the PostgreSQL client to use
- * @param {discord.channels} channels - the discord channels to send messages to
- * @returns {Request} A stream of tweets from the Twitter API
- */
-function streamConnect(token, SQLclient, channels) {
-	const stream = got.stream(streamURL, {
-		headers: {
-			Authorization: `Bearer ${token}`
-		},
-		timeout: {
-			response: 20000
-		}
-	});
-
-    stream.on('data', data => {
-		try {
-			const jsonObj = JSON.parse(data);
-			postMessage(SQLclient, channels, jsonObj)
-				.catch(err => console.log(err));
-		} catch (e) {
-			if (data.detail === 'This stream is currently at the maximum allowed connection limit.') {
-				console.log(data.detail);
-			}
-		}
-    }).on('error', error => {
-		if (error.code !== 'ETIMEDOUT') {
-			console.log(error.code);
-		}
-        else {
-			stream.emit('timeout');
-		}
-	}).on('end', () => {
-		console.log('Twitter Stream End');
-		stream.emit('streamEnd');
-	});
 	
-	console.log("Connected to Twitter Stream");
-
-    return stream;
+    if (response.statusCode !== 201) {
+		throw new Error(response.body);
+    }
 }
+
 
 /**
  * Send new twitter messages to subscribed discord channels, on each new sent tweet  it is stord as the latest tweet for the user
  * @param {pg.Client} SQLclient - Used to query the DB to find the discord channels to send messages to
  * @param {discord.channels} channels - channel manager used to fetch discord channel object based on their ids stored in the DB
- * @param {{data: {id: string, author_id: string, in_reply_to_user_id: string, referenced_tweets?: any[]}, includes: {users: {username: string}[]}}} jsonObj - the JSON object from the Twitter API
+ * @param jsonObj - the JSON object from the Twitter API
  */
 async function postMessage(SQLclient, channels, jsonObj){
 	SQLclient.query('UPDATE latestTweets SET tweetid = $1 WHERE userid = $2', [jsonObj.data.id, jsonObj.data.author_id]);
@@ -167,34 +116,28 @@ async function postMessage(SQLclient, channels, jsonObj){
 	const url = `https://twitter.com/${tag}/status/${jsonObj.data.id}`;
 	const result = await SQLclient.query('SELECT * FROM news WHERE source = $1', [`${tag}-twitter`]);
 	for(const row of result.rows){
-		channels.fetch(row.channel).then(resChann => {
-			if(resChann.guild !== undefined){
-				if(resChann.permissionsFor(resChann.guild.me).has(['SEND_MESSAGES','VIEW_CHANNEL'])){
-					messageHandler.send(resChann, `${baseText}${url}`, "Twitter message");
-				}
-				else{
-					subscriptions.unsubscribeAll(SQLclient, row.channel);
-					console.log(`Unsubscribed from ${row.channel}`);
-				}
-			}
-			else{ // DM
+		try {
+			const resChann = await channels.fetch(row.channel);
+			if (resChann.type === 'DM'){
 				messageHandler.send(resChann, url, "Twitter message");
 			}
-		})
-		.catch(error => {
-			if(error.code !== undefined){
-				if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
-					subscriptions.unsubscribeAll(SQLclient, row.channel);
-					console.log(`Unsubscribed from ${row.channel}`);
-				}
-				else{
-					console.log(error);
-				}
+			else if(resChann.permissionsFor(resChann.guild.me).has(['SEND_MESSAGES','VIEW_CHANNEL'])){
+				messageHandler.send(resChann, `${baseText}${url}`, "Twitter message");
+			}
+			else{
+				subscriptions.unsubscribeAll(SQLclient, row.channel);
+				console.log(`Unsubscribed from ${row.channel}`);
+			}
+		} 
+		catch (error) {
+			if(error?.code == 10003){ //Unknown channel error, thrown when the channel is deleted
+				subscriptions.unsubscribeAll(SQLclient, row.channel);
+				console.log(`Unsubscribed from ${row.channel}`);
 			}
 			else{
 				console.log(error);
 			}
-		})
+		}
 	}
 }
 
@@ -209,10 +152,10 @@ module.exports = {
 			
 			// Delete all rules. Comment the line below if you want to keep your existing rules.
 			await deleteAllRules(currentRules);
-		
+			
 			// Add rules to the stream. Comment the line below if you don't want to add new rules.
 			await setRules();
-		
+			
 		} 
 		catch (e) {
 			console.log("Twitter init issue");
@@ -225,26 +168,49 @@ module.exports = {
 	 * @param {discord.channels} channels - channel manager used to fetch discord channel object based on their ids stored in the DB
 	 * @param {number} timeout - the growth factor for the reconnection logic when the stream times out
 	 */
-	connect: async function (SQLclient, channels, timeout=0) {
+	 connect: async function (SQLclient, channels, timeout=0) {
+		const streamURL = 'https://api.twitter.com/2/tweets/search/stream?&user.fields=username&tweet.fields=in_reply_to_user_id&expansions=referenced_tweets.id,author_id';
+		const stream = got.stream(streamURL, {
+			headers: {
+				Authorization: `Bearer ${token}`
+			},
+			timeout: {
+				response: 20000
+			}
+		});
 		// Listen to the stream.
-		// This reconnection logic will attempt to reconnect when a disconnection is detected.
-		// To avoid rate limits, this logic implements exponential backoff, so the wait time
-		// will increase if the client cannot reconnect to the stream.
-	
-		const filteredStream = streamConnect(token, SQLclient, channels)
-		filteredStream.on('timeout', () => {
-			// Reconnect on error
-			console.log('A twitter connection error occurred. Reconnecting…');
-			setTimeout(() => {
-				timeout++;
-				this.connect(SQLclient, channels, timeout);
-			}, 1000 * (2 ** timeout));
-		}).on('streamEnd', () => {
+		stream.on('data', data => {
+			try {
+				const jsonObj = JSON.parse(data);
+				postMessage(SQLclient, channels, jsonObj);
+			} catch (e) {
+				if (data.detail === 'This stream is currently at the maximum allowed connection limit.') {
+					console.log(data.detail);
+				}
+			}
+		}).on('error', error => {
+			if (error.code !== 'ETIMEDOUT') {
+				console.log(error.code);
+			}
+			else {
+				// This reconnection logic will attempt to reconnect when a disconnection is detected.
+				// To avoid rate limits, this logic implements exponential backoff, so the wait time
+				// will increase if the client cannot reconnect to the stream.
+				console.log('A twitter connection error occurred. Reconnecting…');
+				setTimeout(() => {
+					timeout++;
+					this.connect(SQLclient, channels, timeout);
+				}, 1000 * (2 ** timeout));
+			}
+		}).on('end', () => {
+			console.log('Twitter Stream End');
 			setTimeout(() => {
 				timeout++;
 				this.connect(SQLclient, channels, timeout);
 			},1000 * (2 ** timeout));
 		});
+		
+		console.log("Connected to Twitter Stream");
 	},
 	/**
 	 * Update the latest tweets in the database and post missed tweets to subscribed discord channels

--- a/twitterListener.js
+++ b/twitterListener.js
@@ -262,14 +262,12 @@ module.exports = {
 					}
 				});
 				const json = JSON.parse(response.body);
-				if (json.meta.result_count !== 0) {
-					for (const tweet of json.data) {
-						postMessage(SQLclient, channels, {includes: json.includes, data: tweet});
-					}
-				}
+				const tweets = json.data?.reverse();
+				tweets?.forEach(tweet => {
+					postMessage(SQLclient, channels, {includes: json.includes, data: tweet});
+				});
 			} catch (e) { console.log('Malformed URL request - Table: latestTweets, Column: tweetid or userid is null'); }
 		}
-		// wait 20 minutes and do again
 		setTimeout(() => this.latestTweet(SQLclient, channels), 1200000);
 	}
 }

--- a/twitterListener.js
+++ b/twitterListener.js
@@ -220,19 +220,17 @@ module.exports = {
 	latestTweet: async function(SQLclient, channels) {
 		const res = await SQLclient.query('SELECT userid, tweetid FROM latestTweets');
 		for (const user of res.rows) {
-			try {
-				const response = await got(`https://api.twitter.com/2/users/${user.userid}/tweets?&since_id=${user.tweetid}&user.fields=username&tweet.fields=in_reply_to_user_id&expansions=referenced_tweets.id,author_id`, 
-				{
-					headers: {
-						"authorization": `Bearer ${token}`
-					}
-				});
-				const json = JSON.parse(response.body);
-				const tweets = json.data?.reverse();
-				tweets?.forEach(tweet => {
-					postMessage(SQLclient, channels, {includes: json.includes, data: tweet});
-				});
-			} catch (e) { console.log('Malformed URL request - Table: latestTweets, Column: tweetid or userid is null'); }
+			const response = await got(`https://api.twitter.com/2/users/${user.userid}/tweets?&since_id=${user.tweetid}&user.fields=username&tweet.fields=in_reply_to_user_id&expansions=referenced_tweets.id,author_id`, 
+			{
+				headers: {
+					"authorization": `Bearer ${token}`
+				}
+			});
+			const json = JSON.parse(response.body);
+			const tweets = json.data?.reverse();
+			tweets?.forEach(tweet => {
+				postMessage(SQLclient, channels, {includes: json.includes, data: tweet});
+			});
 		}
 		setTimeout(() => this.latestTweet(SQLclient, channels), 1200000);
 	}


### PR DESCRIPTION
Two main features, support for self-replies and enabling the bot to post missed tweets.

Sometimes `planetside2`/`WrelPlays` will post twitter threads that contain useful information. Unfortunately, the bot did not post any tweets classified as replies. Now when a tracked twitter user creates a thread, the bot will post a new message, labeling it as a `Self-Reply`.

The twitter stream API is how the bot posts tweets in real time but sometimes the API doesn't send tweets. `latestTweet()` gets a tweet timeline that contains any new tweets since tweet id stored in the DB. Any new tweets are posted by the bot and the latest tweet id is updated. There is an edge case where tweets can still be missed if a tracked users' tweets are not sent by the API but then start working again before `latestTweet()` runs. Each time `postMessage()` is called, it sets the sent tweet as the latest tweet id in the DB. If the twitter API sends a new tweet, the latest tweet id will be updated but any missing tweets before the new tweet will never be sent. Hopefully `latestTweet()` running every 20 minutes should be quick enough so that doesn't happen.

As a side note `latestTweet()` won't work until a valid `tweetid` is in the `latestTweets` table. This can be done through manually inserting data into the table. A neat side effect is that the bot catches up on any tweets missed during a restart.
