### PR TITLE
Refactor `.then` to `try catch`

### DIFF
--- a/alertMaintenance.js
+++ b/alertMaintenance.js
@@ -77,12 +77,12 @@ const updateAlert = async function(info, pgClient, discordClient, isComplete){
 	}
 	try {
 		const response = await pgClient.query("SELECT messageID, channelID FROM alertMaintenance WHERE alertID = $1;", [info.instanceId]);
-		await Promise.allSettled(response.rows.map(async row => {
+		response.rows.forEach(async row => {
 			editMessage(messageEmbed, row.messageid, row.channelid, discordClient);
 			if(isComplete){
 				pgClient.query("DELETE FROM alertMaintenance WHERE alertID = $1;", [info.instanceId]);
 			}
-		}));
+		});
 	}
 	catch (err) {
 		console.log("Error editing message");

--- a/alertMaintenance.js
+++ b/alertMaintenance.js
@@ -75,7 +75,6 @@ const updateAlert = async function(info, pgClient, discordClient, isComplete){
 			}
 		}
 	}
-
 	try {
 		const response = await pgClient.query("SELECT messageID, channelID FROM alertMaintenance WHERE alertID = $1;", [info.instanceId]);
 		await Promise.allSettled(response.rows.map(async row => {
@@ -103,16 +102,14 @@ const editMessage = async function(embed, messageId, channelId, discordClient){
 		const resChann = await discordClient.channels.fetch(channelId);
 		if (['GUILD_TEXT','GUILD_NEWS'].includes(resChann.type) && resChann.permissionsFor(resChann.guild.me).has(Discord.Permissions.FLAGS.VIEW_CHANNEL)) {
 			const resMsg = await resChann.messages.fetch(messageId);
-			await resMsg.edit({embeds: [embed]});
+			resMsg.edit({embeds: [embed]});
 		}
 		else if(resChann.type == 'DM'){
 			const resMsg = await resChann.messages.fetch(messageId);
-			await resMsg.edit({embeds: [embed]});
+			resMsg.edit({embeds: [embed]});
 		}
 	}
-	catch(err) {
-		// ignore, will be cleaned up on alert end
-	}
+	catch(err) { /** ignore, will be cleaned up on alert end*/ }
 }
 
 /**

--- a/alertMaintenance.js
+++ b/alertMaintenance.js
@@ -91,7 +91,7 @@ const updateAlert = async function(info, pgClient, discordClient, isComplete){
 }
 
 /**
- * 
+ * Edits existing alert message with new information
  * @param {Discord.MessageEmbed} embed - embed to edit
  * @param {string} messageId - message id to edit
  * @param {string} channelId - channel id to edit	

--- a/alerts.js
+++ b/alerts.js
@@ -6,7 +6,7 @@
 
 const Discord = require('discord.js');
 const alerts = require('./static/alerts.json');
-const got = require('got');
+const {default: got} = require('got');
 const { serverNames, serverIDs } = require('./utils');
 const i18n = require('i18n');
 

--- a/character.js
+++ b/character.js
@@ -11,7 +11,7 @@ const weapons = require('./static/weapons.json');
 const vehicles = require('./static/vehicles.json');
 const decals = require('./static/decals.json');
 const sanction = require('./static/sanction.json');
-const got = require('got');
+const {default: got} = require('got');
 const i18n = require('i18n');
 const { serverNames, badQuery, censusRequest, localeNumber, faction } = require('./utils');
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -6,7 +6,7 @@
  * @typedef {import('pg').Client} pg.Client
  * @typedef {import('discord.js').Client} discord.Client
  * @typedef {import('discord.js').MessageEmbed} discord.MessageEmbed
- * @typedef {import('discord.js').Channel} discord.Channel
+ * @typedef {import('discord.js').TextBasedChannel} discord.Channel
 */
 
 const {MessageEmbed, MessageManager} = require('discord.js');

--- a/main.js
+++ b/main.js
@@ -94,12 +94,14 @@ client.on('ready', async () => {
 			twitterListener.connect(SQLclient, client.channels);
 			twitterListener.latestTweet(SQLclient, client.channels);
 		}
+		/** The bot cycles every 24 hours, so these will be called every 24 hours */
 		outfitMaintenance.update(SQLclient);
 		alertMaintenance.update(SQLclient, client);
 		deleteMessages.run(SQLclient, client);
 		openContinents.check(SQLclient, client);
 		trackers.update(SQLclient, client);
 		dashboard.update(SQLclient, client);
+
 		setInterval(function () { 
 			deleteMessages.run(SQLclient, client);
 			openContinents.check(SQLclient, client);

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -17,30 +17,34 @@ module.exports = {
     send: async function(channel, message, context="default", embed=false){
         let res = -1;
         if(embed && channel.type != 'DM' && !channel.permissionsFor(channel.guild.me).has('EMBED_LINKS')){
-            channel.send('Please grant the "Embed Links" permission to use this command').then(function(result){
+            try {
+                await channel.send('Please grant the "Embed Links" permission to use this command');
                 //message successfully sent, no action needed.
-            }, function(err){
-                console.log("Error sending embed permission message in context: "+context);
-                if(typeof(err.message) !== 'undefined'){
+            }
+            catch (err) {
+                console.log(`Error sending embed permission message in context: ${context}`);
+                if(err.message !== undefined){
                     console.log(err.message);
                 }
-                if(typeof(channel.guild) !== 'undefined'){
+                if(channel.guild !== undefined){
                     console.log(channel.guild.name);
                 }
-            });
+            }
         }
         else{
-            await channel.send(message).then(function(result){
-                res = result.id;
-            }, function(err){
-                console.log("Error sending message in context: "+context);
-                if(typeof(err.message) !== 'undefined'){
+            try {
+                const response = await channel.send(message);
+                return response.id;
+            }
+            catch (err) {
+                console.log(`Error sending message in context: ${context}`);
+                if(err.message !== undefined){
                     console.log(err.message);
                 }
-                if(typeof(channel.guild) !== 'undefined'){
+                if(channel.guild !== undefined){
                     console.log(channel.guild.name);
                 }
-            });
+            }
         }
 
         return res;

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -3,7 +3,7 @@
  * @module messageHandler
  */
 /**
- * @typedef {import('discord.js').TextChannel} discord.Channel
+ * @typedef {import('discord.js').TextBasedChannel} discord.Channel
  */
 module.exports = {
     /**

--- a/openContinents.js
+++ b/openContinents.js
@@ -73,16 +73,16 @@ module.exports = {
 	 * @param {discord.Client} discordClient - discord client to use
 	 */
 	check: async function(pgClient, discordClient){
-		for(const server of servers){
+		servers.forEach(async (server) => {
 			try{
 				const now = new Date().toISOString();
 				const territory = await territoryInfo(serverIDs[server]);
 				const currentStatus = await pgClient.query("SELECT * FROM openContinents WHERE world = $1;", [server]);
-				await pgClient.query("UPDATE openContinents SET indar = $1, hossin = $2, amerish = $3, esamir = $4, oshur = $5, koltyr = $6 WHERE world = $7;",
+				pgClient.query("UPDATE openContinents SET indar = $1, hossin = $2, amerish = $3, esamir = $4, oshur = $5, koltyr = $6 WHERE world = $7;",
 				[territory["Indar"].locked == -1, territory["Hossin"].locked == -1, territory["Amerish"].locked == -1, territory["Esamir"].locked == -1, territory["Oshur"].locked == -1, territory["Koltyr"].locked == -1, server]);
-				for(const cont of continents){
+				continents.forEach(async (cont) => {
 					if(territory[cont].locked != -1){
-						await pgClient.query("DELETE FROM bases WHERE continent = $1 AND world = $2;",
+						pgClient.query("DELETE FROM bases WHERE continent = $1 AND world = $2;",
 						[contIDs[cont], serverIDs[server]]);
 					}
 					else if(!currentStatus.rows[0][cont.toLowerCase()]){
@@ -91,11 +91,11 @@ module.exports = {
 							const result = await pgClient.query("SELECT u.channel, c.Indar, c.Hossin, c.Amerish, c.Esamir, c.Oshur, c.Koltyr, c.autoDelete\
 							FROM unlocks u LEFT JOIN subscriptionConfig c on u.channel = c.channel\
 							WHERE u.world = $1;", [server]);
-							for (const row of result.rows){
+							result.rows.forEach(async (row) => {
 								if(row[cont.toLowerCase()]){
-									await notifyUnlock(cont, serverNames[serverIDs[server]], row.channel, pgClient, discordClient);
+									notifyUnlock(cont, serverNames[serverIDs[server]], row.channel, pgClient, discordClient);
 								}
-							}
+							});
 						}
 						catch(err){
 							console.log("Unlock error");
@@ -105,14 +105,14 @@ module.exports = {
 					}
 					if(territory[cont].locked == -1 != currentStatus.rows[0][cont.toLowerCase()]){
 						// Update timestamp if there is a change
-						await pgClient.query(`UPDATE openContinents SET ${cont.toLowerCase()}change = $1 WHERE world = $2;`, [now, server]);
+						pgClient.query(`UPDATE openContinents SET ${cont.toLowerCase()}change = $1 WHERE world = $2;`, [now, server]);
 					}
-				}
+				});
 			}
 			catch(err){
 				console.log("Error in openContinents");
 				console.log(err);
 			}
-		}
+		});
 	}
 }

--- a/outfitMaintenance.js
+++ b/outfitMaintenance.js
@@ -38,20 +38,20 @@ module.exports = {
 				outfitIDs.push([outfit.id, outfit.platform]);
 			}
 		}
-		for(const id of outfitIDs){
+		outfitIDs.forEach(async (id)=> {
 			try{
 				const response = await censusRequest(platformToEnvironment[id[1]], 'outfit_list', `/outfit/${id[0]}`);
 				if(response.length == 0){
-					continue;
+					return;
 				}
-				await pgClient.query("UPDATE outfitactivity SET alias = $1 WHERE id = $2;", [response[0].alias, id[0]]);
-				await pgClient.query("UPDATE outfitcaptures SET alias = $1, name = $2 WHERE id = $3;", [response[0].alias, response[0].name, id[0]]);	
+				pgClient.query("UPDATE outfitactivity SET alias = $1 WHERE id = $2;", [response[0].alias, id[0]]);
+				pgClient.query("UPDATE outfitcaptures SET alias = $1, name = $2 WHERE id = $3;", [response[0].alias, response[0].name, id[0]]);	
 			}
 			catch(err){
 				console.log('Outfit maintenance error');
 				console.log(id);
 				console.log(err);
 			}
-		}
+		});
 	}
 }

--- a/outfitMaintenance.js
+++ b/outfitMaintenance.js
@@ -23,7 +23,7 @@ const platformToEnvironment = {
 
 module.exports = {
 	/**
-	 * Update outfit login/logouts and outfit captures for current subscribed channels
+	 * Update current outfit tag/name to new tag/name if it has changed
 	 * @param {pg.Client} pgClient - Postgres client to use
 	 */
 	update: async function(pgClient){

--- a/population.js
+++ b/population.js
@@ -4,7 +4,7 @@
  */
 
 const Discord = require('discord.js');
-const got = require('got')
+const {default: got} = require('got')
 const {servers, serverIDs, serverNames, localeNumber} = require('./utils.js');
 const i18n = require('i18n');
 

--- a/trackers.js
+++ b/trackers.js
@@ -24,7 +24,7 @@ const populationName = async function(serverID){
 }
 
 /**
- * Get open continents on serveer
+ * Get open continents on server
  * @param {number} serverID - the server to check open continents
  * @returns which continents are open on the  server
  */

--- a/unifiedWSHandler.js
+++ b/unifiedWSHandler.js
@@ -251,7 +251,7 @@ const alertEvent = async function(payload, environment, pgClient, discordClient)
                 \n<:NC:818767043138027580> **NC**: ${ncPc}%\
                 \n<:TR:818988588049629256> **TR**: ${trPc}%`);
             }
-            const  rows = await pgClient.query("SELECT a.channel, c.Koltyr, c.Indar, c.Hossin, c.Amerish, c.Esamir, c.Oshur, c.Other, c.autoDelete, c.territory, c.nonTerritory\
+            const  result = await pgClient.query("SELECT a.channel, c.Koltyr, c.Indar, c.Hossin, c.Amerish, c.Esamir, c.Oshur, c.Other, c.autoDelete, c.territory, c.nonTerritory\
             FROM alerts a LEFT JOIN subscriptionConfig c on a.channel = c.channel\
             WHERE a.world = $1;", [server.toLowerCase()]);
             result.rows.forEach(async (row) => {
@@ -549,20 +549,24 @@ module.exports = {
         queue.shift();
 
         if(payload.character_id != null){
-            try { await logEvent(payload, environment, pgClient, discordClient) }
-            catch (error) {
+            logEvent(payload, environment, pgClient, discordClient)
+            .catch(error => {
                 if(typeof(error) == "string" && error != "Census API currently unavailable" && error != "Census API unavailable: Redirect"){
                     console.log(`Login error: ${error}`);
                 }
-            }
+            });
         }
         else if(payload.metagame_event_state_name != null){
-            try { await alertEvent(payload, environment, pgClient, discordClient) }
-            catch (error) { console.log(error); } 
+            alertEvent(payload, environment, pgClient, discordClient)
+            .catch(error => {
+                console.log(error);
+            }); 
         }
         else if(payload.duration_held != null){
-            try { await baseEvent(payload, environment, pgClient, discordClient) }
-            catch (error) { console.log(error); } 
+            baseEvent(payload, environment, pgClient, discordClient)
+            .catch(error => {
+                console.log(error);
+            }); 
         }
     }
 }

--- a/unifiedWSHandler.js
+++ b/unifiedWSHandler.js
@@ -533,7 +533,7 @@ const baseInfo = async function(facilityID, environment){
 const queue = ["","","","",""];
 module.exports = {
     /**
-     * Send an alert event and base event to all subscribed channels
+     * Send an alert, base, login or logout event to all subscribed channels
      * @param payload - the payload of the event
      * @param {string} environment - the environment the event was sent from
      * @param {pg.Client} pgClient - the postgres client to use

--- a/unifiedWSHandler.js
+++ b/unifiedWSHandler.js
@@ -58,52 +58,43 @@ const logEvent = async function(payload, environment, pgClient, discordClient){
             sendEmbed.setTitle(result.rows[0].alias+' '+playerEvent);
             sendEmbed.setDescription(char.name.first);
             sendEmbed.setColor(faction(char.faction_id).color);
-            for (let row of result.rows){
-                discordClient.channels.fetch(row.channel)
-                    .then(resChann => {
-                        if(typeof(resChann.guild) !== 'undefined'){
-                            if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
-                                messageHandler.send(resChann, {embeds: [sendEmbed]}, "Log event")
-                                .then(messageId => {
-                                    if(messageId != -1 && row.autodelete == true){
-                                        const in5minutes = new Date((new Date()).getTime() + 300000);
-                                        pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in5minutes])
-                                            .catch(err => {console.log(err);});
-                                    }
-                                });
-                                
-                            }
-                            else{
-                                subscriptions.unsubscribeAll(pgClient, row.channel);
-                                console.log('Unsubscribed from '+row.channel);
-                            } 
+            for (const row of result.rows){
+                try {
+                    const resChann = await discordClient.channels.fetch(row.channel);
+                    if(resChann.type === 'DM') { // DM
+                        const messageId = await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Log event");
+                        if(messageId != -1 && row.autodelete === true){
+                            const in5minutes = new Date((new Date()).getTime() + 30000);
+                            try { await pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in5minutes]); }
+                            catch (err) { console.log(err); }
                         }
-                        else{ // DM
-                            messageHandler.send(resChann, {embeds: [sendEmbed]}, "Log event")
-                            .then(messageId => {
-                                if(messageId != -1 && row.autodelete === true){
-                                    const in5minutes = new Date((new Date()).getTime() + 30000);
-                                    pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in5minutes])
-                                        .catch(err => {console.log(err);});
-                                }
-                                else if(messageId == -1){
-                                    subscriptions.unsubscribeAll(pgClient, row.channel);
-                                    console.log('Unsubscribed from '+row.channel);
-                                }
-                            })
-                        }                        
-                    })
-                    .catch(error => {
-                        if(typeof(error.code) !== 'undefined'){
-                            if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
-                                subscriptions.unsubscribeAll(pgClient, row.channel);
-                                console.log('Unsubscribed from '+row.channel);
-                            }
+                        else if(messageId == -1){
+                            await subscriptions.unsubscribeAll(pgClient, row.channel);
+                            console.log(`Unsubscribed from ${row.channel}`);
                         }
-                        else{
-                            console.log(error);
+                    }                        
+                    else if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
+                        const messageId = await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Log event");
+                        if(messageId != -1 && row.autodelete == true){
+                            const in5minutes = new Date((new Date()).getTime() + 300000);
+                            try { await pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in5minutes]); }
+                            catch (err) { console.log(err); }
                         }
-                    });
+                    }
+                    else{
+                        await subscriptions.unsubscribeAll(pgClient, row.channel);
+                        console.log(`Unsubscribed from ${row.channel}`);
+                    } 
+                }
+                catch (error) {
+                    if(error.code === undefined){
+                        console.log(error);
+                    }
+                    else if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
+                        await subscriptions.unsubscribeAll(pgClient, row.channel);
+                        console.log(`Unsubscribed from ${row.channel}`);
+                    }
+                }
             }
         }
     }
@@ -263,79 +254,71 @@ const alertEvent = async function(payload, environment, pgClient, discordClient)
             let rows = await pgClient.query("SELECT a.channel, c.Koltyr, c.Indar, c.Hossin, c.Amerish, c.Esamir, c.Oshur, c.Other, c.autoDelete\
             FROM alerts a LEFT JOIN subscriptionConfig c on a.channel = c.channel\
             WHERE a.world = $1;", [server.toLowerCase()]);
-            for (let row of rows.rows){
+            for (const row of rows.rows){
                 if(row[continent.toLowerCase()] == null){
                     config.initializeConfig(row.channel, pgClient);
                 }
                 else if(row[continent.toLowerCase()] == false){
                     continue;
                 }
-                discordClient.channels.fetch(row.channel)
-                    .then(resChann => {
-                        if(typeof(resChann.guild) !== 'undefined'){
-                            if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
-                                messageHandler.send(resChann, {embeds: [sendEmbed]}, "Alert notification")
-                                .then(messageId => {
-                                    if(messageId != -1 && trackedAlerts.indexOf(Number(payload.metagame_event_id)) > -1){
-                                        pgClient.query("INSERT INTO alertMaintenance (alertID, messageID, channelID) VALUES ($1, $2, $3);", [`${payload.world_id}-${payload.instance_id}`, messageId, row.channel])
-                                            .catch(err => {console.log(err);});
-                                    }
-                                    if(messageId != -1 && row.autodelete === true){
-                                        const in50minutes = new Date((new Date()).getTime() + 3000000);
-                                        const in95minutes = new Date((new Date()).getTime() + 5700000);
-                                        if(['Indar', 'Hossin', 'Esamir', 'Amerish', 'Oshur'].includes(continent) && response.name.indexOf("Unstable Meltdown") == -1){
-                                            pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in95minutes])
-                                            .catch(err => {console.log(err);});
-                                        }
-                                        else{
-                                            pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in50minutes])
-                                            .catch(err => {console.log(err);});
-                                        }    
-                                    }
-                                });
+                try {
+                    const resChann = await discordClient.channels.fetch(row.channel);
+                    if (resChann.type === 'DM'){ // DM
+                        const messageId = await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Alert notification");
+                        if(messageId != -1 && trackedAlerts.indexOf(Number(payload.metagame_event_id)) > -1){
+                            try { await pgClient.query("INSERT INTO alertMaintenance (alertID, messageID, channelID) VALUES ($1, $2, $3);", [`${payload.world_id}-${payload.instance_id}`, messageId, row.channel]); }
+                            catch (err) { console.log(err); }
+                        }
+                        if(messageId != -1 && row.autodelete === true){
+                            const in50minutes = new Date((new Date()).getTime() + 3000000);
+                            const in95minutes = new Date((new Date()).getTime() + 5700000);
+                            if(['Indar', 'Hossin', 'Esamir', 'Amerish', 'Oshur'].includes(continent) && response.name.indexOf("Unstable Meltdown") == -1){
+                                try { pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in95minutes]); }
+                                catch (err) { console.log(err); }
                             }
                             else{
-                                subscriptions.unsubscribeAll(pgClient, row.channel);
-                                console.log('Unsubscribed from '+row.channel);
-                            } 
+                                try { pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in50minutes]); }
+                                catch (err) { console.log(err); }
+                            }    
                         }
-                        else{ // DM
-                            messageHandler.send(resChann, {embeds: [sendEmbed]}, "Alert notification")
-                            .then(messageId => {
-                                if(messageId != -1 && trackedAlerts.indexOf(Number(payload.metagame_event_id)) > -1){
-                                    pgClient.query("INSERT INTO alertMaintenance (alertID, messageID, channelID) VALUES ($1, $2, $3);", [`${payload.world_id}-${payload.instance_id}`, messageId, row.channel])
-                                        .catch(err => {console.log(err);})
-                                }
-                                if(messageId != -1 && row.autodelete === true){
-                                    const in50minutes = new Date((new Date()).getTime() + 3000000);
-                                    const in95minutes = new Date((new Date()).getTime() + 5700000);
-                                    if(['Indar', 'Hossin', 'Esamir', 'Amerish', 'Oshur'].includes(continent) && response.name.indexOf("Unstable Meltdown") == -1){
-                                        pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in95minutes])
-                                        .catch(err => {console.log(err);});
-                                    }
-                                    else{
-                                        pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in50minutes])
-                                        .catch(err => {console.log(err);});
-                                    }    
-                                }
-                                else if(messageId == -1){
-                                    subscriptions.unsubscribeAll(pgClient, row.channel);
-                                    console.log('Unsubscribed from '+row.channel);
-                                }
-                            });
-                        } 
-                    })
-                    .catch(error => {
-                        if(typeof(error.code) !== 'undefined'){
-                            if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
-                                subscriptions.unsubscribeAll(pgClient, row.channel);
-                                console.log('Unsubscribed from '+row.channel);
+                        else if(messageId == -1){
+                            await subscriptions.unsubscribeAll(pgClient, row.channel);
+                            console.log(`Unsubscribed from ${row.channel}`);
+                        }
+                    }
+                    else if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
+                        const messageId = await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Alert notification");
+                        if(messageId != -1 && trackedAlerts.indexOf(Number(payload.metagame_event_id)) > -1){
+                            try { await pgClient.query("INSERT INTO alertMaintenance (alertID, messageID, channelID) VALUES ($1, $2, $3);", [`${payload.world_id}-${payload.instance_id}`, messageId, row.channel]); }
+                            catch (err) { console.log(err); };
+                        }
+                        if(messageId != -1 && row.autodelete === true){
+                            const in50minutes = new Date((new Date()).getTime() + 3000000);
+                            const in95minutes = new Date((new Date()).getTime() + 5700000);
+                            if(['Indar', 'Hossin', 'Esamir', 'Amerish', 'Oshur'].includes(continent) && response.name.indexOf("Unstable Meltdown") == -1){
+                                try { pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in95minutes]); }
+                                catch (err) { console.log(err); }
+                            }
+                            else{
+                                try { pgClient.query("INSERT INTO toDelete (channel, messageID, timeToDelete) VALUES ($1, $2, $3)", [row.channel, messageId, in50minutes]); }
+                                catch (err) { console.log(err); }
                             }
                         }
-                        else{
-                            console.log(error);
-                        }
-                    });
+                    }
+                    else{
+                        await subscriptions.unsubscribeAll(pgClient, row.channel);
+                        console.log(`Unsubscribed from ${row.channel}`);
+                    } 
+                }
+                catch (error) {
+                    if (error.code === undefined){
+                        console.log(error);
+                    }
+                    else if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
+                        await subscriptions.unsubscribeAll(pgClient, row.channel);
+                        console.log(`Unsubscribed from ${row.channel}`);
+                    }
+                }
             }
         }
     }
@@ -428,31 +411,29 @@ const baseEvent = async function(payload, environment, pgClient, discordClient){
         if(contributions.length > 0){
             sendEmbed.addField("<:Merit:890295314337136690> Contributors", `${contributions}`.replace(/,/g, ', '), true);
         }
-        for (let row of result.rows){
-            discordClient.channels.fetch(row.channel).then(resChann => {
-                if(typeof(resChann.guild) !== 'undefined'){
-                    if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
-                        messageHandler.send(resChann, {embeds: [sendEmbed]}, "Base capture event");
-                    }
-                    else{
-                        subscriptions.unsubscribeAll(pgClient, row.channel);
-                        console.log('Unsubscribed from '+row.channel);
-                    }
+        for (const row of result.rows){
+            try {
+                const resChann = await discordClient.channels.fetch(row.channel);
+                if(resChann.type === 'DM'){ // DM
+                    await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Base capture event");
                 }
-                else{ // DM
-                    messageHandler.send(resChann, {embeds: [sendEmbed]}, "Base capture event");
-                }
-            }).catch(error => {
-                if(typeof(error.code) !== 'undefined'){
-                    if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
-                        subscriptions.unsubscribeAll(pgClient, row.channel);
-                        console.log('Unsubscribed from '+row.channel);
-                    }
+                else if(resChann.permissionsFor(resChann.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
+                    await messageHandler.send(resChann, {embeds: [sendEmbed]}, "Base capture event");
                 }
                 else{
+                    await subscriptions.unsubscribeAll(pgClient, row.channel);
+                    console.log(`Unsubscribed from ${row.channel}`);
+                }
+            }
+            catch (error) {
+                if(error.code === undefined){
                     console.log(error);
                 }
-            });
+                else if(error.code == 10003){ //Unknown channel error, thrown when the channel is deleted
+                    await subscriptions.unsubscribeAll(pgClient, row.channel);
+                    console.log(`Unsubscribed from ${row.channel}`);
+                }
+            }
         }
     }
 }
@@ -566,20 +547,20 @@ module.exports = {
         queue.shift();
 
         if(payload.character_id != null){
-            logEvent(payload, environment, pgClient, discordClient)
-                .catch(error => {
-                    if(typeof(error) == "string" && error != "Census API currently unavailable" && error != "Census API unavailable: Redirect"){
-                        console.log("Login error: "+error);
-                    }
-                });
+            try { await logEvent(payload, environment, pgClient, discordClient) }
+            catch (error) {
+                if(typeof(error) == "string" && error != "Census API currently unavailable" && error != "Census API unavailable: Redirect"){
+                    console.log(`Login error: ${error}`);
+                }
+            }
         }
         else if(payload.metagame_event_state_name != null){
-            alertEvent(payload, environment, pgClient, discordClient)
-                .catch(error => console.log(error));
+            try { await alertEvent(payload, environment, pgClient, discordClient) }
+            catch (error) { console.log(error); } 
         }
         else if(payload.duration_held != null){
-            baseEvent(payload, environment, pgClient, discordClient)
-                .catch(error => console.log(error));
+            try { await baseEvent(payload, environment, pgClient, discordClient) }
+            catch (error) { console.log(error); } 
         }
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,7 @@
  * @module utils
  */
 
-const got = require('got');
+const {default: got} = require('got');
 
 /**
  * A list of the different servers all lowercase
@@ -151,7 +151,7 @@ function localeNumber(n, locale){
 function faction(factionID){
 	/**
 	 * @typedef {Object} faction
-	 * @property {string} color - faction color
+	 * @property {import('discord.js').ColorResolvable} color - faction color
 	 * @property {string} decal - faction decal
 	 * @property {string} initial - faction initial
 	 * @property {string} tracker - faction color emoji	


### PR DESCRIPTION
Two changes, `{default: }` modifier for importing `got` which means intellisense should work on `got` objects now. The second change is moving from using `.then` to `try catch`. The originally behavior created promises in parallel which should be replicated, but now with `try catch` `await`.

As far as I can tell the only time we need to really worry about how concurrency works for `await` and `.then` is with loops. If it's in an async function body, then they work exactly the same.

This would currently apply to `alertMaintenance.js`, `dashboard.js`, `openContinents.js`, `outfitMaintenance.js`, `trackers.js`, and `unifiedWSHandler.js`.