### PR TITLE
`alerts.js` Small bugfix

### DIFF
--- a/alerts.js
+++ b/alerts.js
@@ -14,11 +14,12 @@ const i18n = require('i18n');
  * The possible population levels of a server
  */
 const popLevels = {
-	1: "Dead",
-	2: "Low",
-	3: "Medium",
-	4: "High",
-	5: "Prime"
+	"-1": "Unknown",
+	"1": "Dead",
+	"2": "Low",
+	"3": "Medium",
+	"4": "High",
+	"5": "Prime"
 };
 
 /**


### PR DESCRIPTION
- Sometimes the alert API will return -1 for `bracket`, this PR fixes a `RangeError` that gets thrown when `bracket` is `-1` which results in the population level being `undefined`, resulting in a `RangeError` for `.addField()/.addFields()`. 