### PR TITLE
Changes that hopefully make it easier to update to `discord.js` v14

### DIFF
--- a/alerts.js
+++ b/alerts.js
@@ -4,7 +4,7 @@
  * @module alerts
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const alerts = require('./static/alerts.json');
 const got = require('got');
 const { serverNames, serverIDs } = require('./utils');
@@ -95,22 +95,23 @@ module.exports = {
 		catch(err){
 			throw err;
 		}
-		let sendEmbed = new Discord.MessageEmbed();
+		const sendEmbed = new EmbedBuilder();
 		sendEmbed.setTitle(serverNames[serverID]+" alerts");
 		sendEmbed.setFooter({text: i18n.__mf({phrase: "Data from {site}", locale: locale}, {site: "ps2alerts.com"})});
 		sendEmbed.setTimestamp();
 		for(const x in alertObj){
-			sendEmbed.addField(alertObj[x].name, "["+alertObj[x].description+"](https://ps2alerts.com/alert/"+alertObj[x].instanceId+"?utm_source=auraxis-bot&utm_medium=discord&utm_campaign=partners)");
-			sendEmbed.addField(i18n.__({phrase: "Start time", locale: locale}), `<t:${alertObj[x].timeStart}:t>`, true);
-			sendEmbed.addField(i18n.__({phrase: "Time left", locale: locale}), 
-			i18n.__mf({phrase: "Ends {time}", locale: locale}, {time: `<t:${alertObj[x].timeEnd}:R>`}), true);
-			sendEmbed.addField(i18n.__({phrase: "Activity Level", locale: locale}), i18n.__({phrase: popLevels[alertObj[x].bracket], locale: locale}), true);
-			sendEmbed.addField(i18n.__({phrase: "Territory Control", locale: locale}), `\
-			\n<:VS:818766983918518272> **${i18n.__({phrase: "VS", locale: locale})}**: ${alertObj[x].vs}%\
-			\n<:NC:818767043138027580> **${i18n.__({phrase: "NC", locale: locale})}**: ${alertObj[x].nc}%\
-			\n<:TR:818988588049629256> **${i18n.__({phrase: "TR", locale: locale})}**: ${alertObj[x].tr}%`);
+			sendEmbed.addFields([
+				{name: alertObj[x].name, value: "["+alertObj[x].description+"](https://ps2alerts.com/alert/"+alertObj[x].instanceId+"?utm_source=auraxis-bot&utm_medium=discord&utm_campaign=partners)"},
+				{name: i18n.__({phrase: "Start time", locale: locale}), value: `<t:${alertObj[x].timeStart}:t>`, inline: true},
+				{name: i18n.__({phrase: "Time left", locale: locale}), value: i18n.__mf({phrase: "Ends {time}", locale: locale}, {time: `<t:${alertObj[x].timeEnd}:R>`}), inline: true},
+				{name: i18n.__({phrase: "Activity Level", locale: locale}), value: i18n.__({phrase: popLevels[alertObj[x].bracket], locale: locale}), inline: true},
+				{name: i18n.__({phrase: "Territory Control", locale: locale}), value: `\
+					\n<:VS:818766983918518272> **${i18n.__({phrase: "VS", locale: locale})}**: ${alertObj[x].vs}%\
+					\n<:NC:818767043138027580> **${i18n.__({phrase: "NC", locale: locale})}**: ${alertObj[x].nc}%\
+					\n<:TR:818988588049629256> **${i18n.__({phrase: "TR", locale: locale})}**: ${alertObj[x].tr}%`}
+			]);
 			if(x != alertObj.length-1){
-				sendEmbed.addField('\u200b', '\u200b');
+				sendEmbed.addFields({name: '\u200b', value: '\u200b'});
 			}
 		}
 		return sendEmbed;

--- a/auraxiums.js
+++ b/auraxiums.js
@@ -4,7 +4,8 @@
  */
 
 const {censusRequest, faction} = require('./utils.js');
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder, MessageActionRow: ActionRowBuilder, MessageButton: ButtonBuilder} = require('discord.js');
+const { ButtonStyle } = require('discord-api-types/v10');
 const sanction = require('./static/sanction.json');
 const { localeNumber } = require('./utils.js');
 const i18n = require('i18n');
@@ -75,7 +76,7 @@ module.exports = {
 	medals: async function(cName, platform, expanded=false, locale='en-US'){
 		const medalList = await getAuraxiumList(cName.toLowerCase(), platform, locale);
 
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		resEmbed.setTitle(i18n.__mf({phrase: "{name} Auraxiums", locale: locale}, {name: medalList.name}));
 		let textList = "";
 		let remaining = medalList.medals.length + medalList.possibleMedals.length;
@@ -93,7 +94,7 @@ module.exports = {
 					textList = currentItem;
 				}
 				else if(continued && (textList.length + currentItem.length) > 1024){
-					resEmbed.addField(i18n.__({phrase: "Continued...", locale: locale}), textList);
+					resEmbed.addFields({name: i18n.__({phrase: "Continued...", locale: locale}), value: textList});
 					textList = currentItem;
 				}
 				else{
@@ -101,7 +102,7 @@ module.exports = {
 				}
 			}
 			if(continued){
-				resEmbed.addField(i18n.__({phrase: "Continued...", locale: locale}), textList);
+				resEmbed.addFields({name: i18n.__({phrase: "Continued...", locale: locale}), value: textList});
 			}
 			else{
 				resEmbed.setDescription(textList);
@@ -114,11 +115,11 @@ module.exports = {
 				const currentItem = `${medal}\n`;
 				if(!continued && (textList.length + currentItem.length) > 1024){
 					continued = true;
-					resEmbed.addField(i18n.__({phrase: "Possible medals (kills)", locale: locale}), textList);
+					resEmbed.addFields({value: i18n.__({phrase: "Possible medals (kills)", locale: locale}), name: textList});
 					textList = currentItem;
 				}
 				else if(continued && (textList.length + currentItem.length) > 1024){
-					resEmbed.addField(i18n.__({phrase: "Continued...", locale: locale}), textList);
+					resEmbed.addFields({name: i18n.__({phrase: "Continued...", locale: locale}), value: textList});
 					textList = currentItem;
 				}
 				else{
@@ -126,10 +127,10 @@ module.exports = {
 				}
 			}
 			if(continued){
-				resEmbed.addField(i18n.__({phrase: "Continued...", locale: locale}), textList);
+				resEmbed.addFields({name: i18n.__({phrase: "Continued...", locale: locale}), value: textList});
 			}
 			else if(textList != ""){
-				resEmbed.addField(i18n.__({phrase: "Possible medals (kills)", locale: locale}), textList);
+				resEmbed.addFields({value: i18n.__({phrase: "Possible medals (kills)", locale: locale}), name: textList});
 			}
 		}
 		else{
@@ -160,7 +161,7 @@ module.exports = {
 					remaining -= 1;
 					max -= 1;
 				}
-				resEmbed.addField(i18n.__({phrase: "Possible medals (kills)", locale: locale}), textList);
+				resEmbed.addFields({value: i18n.__({phrase: "Possible medals (kills)", locale: locale}), name: textList});
 			}
 		}
 		resEmbed.setColor(faction(medalList.faction).color)
@@ -175,12 +176,12 @@ module.exports = {
 			resEmbed.setURL(`https://ps4eu.ps2.fisu.pw/player/?name=${medalList.name}&show=weapons`);
 		}
 		if(remaining > 0){
-			const row = new Discord.MessageActionRow()
+			const row = new ActionRowBuilder()
 			row.addComponents(
-				new Discord.MessageButton()
+				new ButtonBuilder()
 					.setCustomId(`auraxiums%${medalList.name}%${platform}`)
 					.setLabel(i18n.__({phrase: "View all", locale: locale}))
-					.setStyle('PRIMARY')
+					.setStyle(ButtonStyle.Primary)
 			);
 			return [resEmbed, [row]];
 		}

--- a/character.js
+++ b/character.js
@@ -6,7 +6,8 @@
  */
 
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder, MessageActionRow: ActionRowBuilder, MessageButton: ButtonBuilder} = require('discord.js');
+const { ButtonStyle } = require('discord-api-types/v10');
 const weapons = require('./static/weapons.json');
 const vehicles = require('./static/vehicles.json');
 const decals = require('./static/decals.json');
@@ -384,21 +385,21 @@ module.exports = {
 		}
         
         const cInfo = await basicInfo(cName, platform);
-        let resEmbed = new Discord.MessageEmbed();
-        const row = new Discord.MessageActionRow()
+        const resEmbed = new EmbedBuilder();
+        const row = new ActionRowBuilder()
         row.addComponents(
-            new Discord.MessageButton()
+            new ButtonBuilder()
                 .setCustomId(`recentStats%30%${cInfo.characterID}%${platform}`)
                 .setLabel(i18n.__({phrase: '30 day stats', locale: locale}))
-                .setStyle('PRIMARY'),
-            new Discord.MessageButton()
+                .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder()
                 .setCustomId(`recentStats%7%${cInfo.characterID}%${platform}`)
                 .setLabel(i18n.__({phrase: '7 day stats', locale: locale}))
-                .setStyle('PRIMARY'),
-            new Discord.MessageButton()
+                .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder()
                 .setCustomId(`recentStats%1%${cInfo.characterID}%${platform}`)
                 .setLabel(i18n.__({phrase: '1 day stats', locale: locale}))
-                .setStyle('PRIMARY')
+                .setStyle(ButtonStyle.Primary)
         );
 
         // Username, title, fisu url
@@ -418,10 +419,10 @@ module.exports = {
         
         // BR & ASP
         if(cInfo.prestige > 0){
-            resEmbed.addField(i18n.__({phrase: 'BR', locale: locale}), cInfo.br+"~"+cInfo.prestige, true);
+            resEmbed.addFields({name: i18n.__({phrase: 'BR', locale: locale}), value: cInfo.br+"~"+cInfo.prestige, inline: true});
         }
         else{
-            resEmbed.addField(i18n.__({phrase: 'BR', locale: locale}), cInfo.br, true);
+            resEmbed.addFields({name: i18n.__({phrase: 'BR', locale: locale}), value: cInfo.br, inline: true});
         }
 
         // Decal thumbnail
@@ -449,80 +450,82 @@ module.exports = {
 
         // Score, SPM
         if(cInfo.stat_history){
-            resEmbed.addField(i18n.__({phrase: 'Score (SPM)', locale: locale}), parseInt(cInfo.score).toLocaleString(locale)+" ("+localeNumber(cInfo.score/cInfo.playTime, locale)+")", true);
+            resEmbed.addFields({name: i18n.__({phrase: 'Score (SPM)', locale: locale}), value: parseInt(cInfo.score).toLocaleString(locale)+" ("+localeNumber(cInfo.score/cInfo.playTime, locale)+")", inline: true});
         }
 
         // Server
-        resEmbed.addField(i18n.__({phrase: 'Server', locale: locale}), i18n.__({phrase: serverNames[Number(cInfo.server)], locale: locale}), true);
+        resEmbed.addFields({name: i18n.__({phrase: 'Server', locale: locale}), value: i18n.__({phrase: serverNames[Number(cInfo.server)], locale: locale}), inline: true});
 
         // Playtime
         const hours = Math.floor(cInfo.playTime/60);
         const minutesPlayed = cInfo.playTime - hours*60;
-        resEmbed.addField(i18n.__({phrase: 'Playtime', locale: locale}), 
+        resEmbed.addFields({name: i18n.__({phrase: 'Playtime', locale: locale}), value:
         `${i18n.__mf({phrase: "{hour} hours, {minute} minutes", locale: locale}, 
-        {hour: localeNumber(hours, locale), minute: minutesPlayed})}`, true);
+        {hour: localeNumber(hours, locale), minute: minutesPlayed})}`, inline: true});
         
         // KD, KPM
         if(cInfo.stat_history){
-            resEmbed.addField(i18n.__({phrase: 'K/D', locale: locale}), localeNumber(cInfo.kills/cInfo.deaths, locale), true);
-            resEmbed.addField(i18n.__({phrase: 'KPM', locale: locale}), localeNumber(cInfo.kills/cInfo.playTime, locale), true);
-            resEmbed.addField(i18n.__({phrase: 'K-D Diff', locale: locale}), `${Number.parseInt(cInfo.kills).toLocaleString(locale)} - ${Number.parseInt(cInfo.deaths).toLocaleString(locale)} = ${(cInfo.kills-cInfo.deaths).toLocaleString(locale, {signDisplay: "exceptZero"})}`, true);
+            resEmbed.addFields([
+                {name: i18n.__({phrase: 'K/D', locale: locale}), value: localeNumber(cInfo.kills/cInfo.deaths, locale), inline: true},
+                {name: i18n.__({phrase: 'KPM', locale: locale}), value: localeNumber(cInfo.kills/cInfo.playTime, locale), inline: true},
+                {name: i18n.__({phrase: 'K-D Diff', locale: locale}), value: `${Number.parseInt(cInfo.kills).toLocaleString(locale)} - ${Number.parseInt(cInfo.deaths).toLocaleString(locale)} = ${(cInfo.kills-cInfo.deaths).toLocaleString(locale, {signDisplay: "exceptZero"})}`, inline: true}
+            ]);
         }
 
         // IVI Score
         if(typeof(cInfo.infantryHeadshots) !== 'undefined' && typeof(cInfo.infantryHits) !== 'undefined'){
             let accuracy = cInfo.infantryHits/cInfo.infantryShots;
             let hsr = cInfo.infantryHeadshots/cInfo.infantryKills;
-            resEmbed.addField(i18n.__({phrase: 'IVI Score', locale: locale}), `${Math.round(accuracy*hsr*10000)}`, true);
+            resEmbed.addFields({name: i18n.__({phrase: 'IVI Score', locale: locale}), value: `${Math.round(accuracy*hsr*10000)}`, inline: true});
         }
 
         // Online status
         if (cInfo.online == "service_unavailable"){
-            resEmbed.addField(i18n.__({phrase: 'Online', locale: locale}), 'Service unavailable', true);
+            resEmbed.addFields({ name: i18n.__({phrase: 'Online', locale: locale}), value: 'Service unavailable', inline: true});
         }
         else if (cInfo.online >= 1){
-            resEmbed.addField(i18n.__({phrase: 'Online', locale: locale}), ':white_check_mark:', true);
+            resEmbed.addFields({name: i18n.__({phrase: 'Online', locale: locale}), value: ':white_check_mark:', inline: true});
         }
         else{
-            resEmbed.addField(i18n.__({phrase: 'Online', locale: locale}), ':x:', true);
+            resEmbed.addFields({name: i18n.__({phrase: 'Online', locale: locale}), value: ':x:', inline: true});
         }
-        resEmbed.addField(i18n.__({phrase: 'Last Login', locale: locale}), `<t:${cInfo.lastLogin}:R>`, true);
+        resEmbed.addFields({name: i18n.__({phrase: 'Last Login', locale: locale}), value: `<t:${cInfo.lastLogin}:R>`, inline: true});
 
         const factionInfo = faction(cInfo.faction);
-        resEmbed.addField(i18n.__({phrase: 'Faction', locale: locale}), `${factionInfo.decal} ${i18n.__({phrase: factionInfo.initial, locale: locale})}`, true);
+        resEmbed.addFields({name: i18n.__({phrase: 'Faction', locale: locale}), value: `${factionInfo.decal} ${i18n.__({phrase: factionInfo.initial, locale: locale})}`, inline: true});
 
         resEmbed.setColor(factionInfo.color);
 
         // Outfit info
         if(cInfo.inOutfit){
             if(cInfo.outfitAlias != "" && platform == 'ps2:v2'){
-                resEmbed.addField(i18n.__({phrase: 'Outfit', locale: locale}), '[['+cInfo.outfitAlias+']](https://ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, true);
+                resEmbed.addFields({ name: i18n.__({phrase: 'Outfit', locale: locale}), value: '[['+cInfo.outfitAlias+']](https://ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, inline: true});
             }
             else if(cInfo.outfitAlias != "" && platform == 'ps2ps4us:v2'){
-                resEmbed.addField(i18n.__({phrase: 'Outfit', locale: locale}), '[['+cInfo.outfitAlias+']](https://ps4us.ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Outfit', locale: locale}), value: '[['+cInfo.outfitAlias+']](https://ps4us.ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, inline: true});
             }
             else if(cInfo.outfitAlias != "" && platform == 'ps2ps4eu:v2'){
-                resEmbed.addField(i18n.__({phrase: 'Outfit', locale: locale}), '[['+cInfo.outfitAlias+']](https://ps4eu.ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Outfit', locale: locale}), value: '[['+cInfo.outfitAlias+']](https://ps4eu.ps2.fisu.pw/outfit/?name='+cInfo.outfitAlias+') '+cInfo.outfitName, inline: true});
             }
             else{
-                resEmbed.addField(i18n.__({phrase: 'Outfit', locale: locale}), cInfo.outfitName, true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Outfit', locale: locale}), value: cInfo.outfitName, inline: true});
             }
-            resEmbed.addField(i18n.__({phrase: 'Outfit Rank', locale: locale}), `${cInfo.outfitRank} (${cInfo.outfitRankOrdinal})`, true);
+            resEmbed.addFields({name: i18n.__({phrase: 'Outfit Rank', locale: locale}), value: `${cInfo.outfitRank} (${cInfo.outfitRankOrdinal})`, inline: true});
             row.addComponents(
-                new Discord.MessageButton()
+                new ButtonBuilder()
                     .setCustomId(`outfit%${cInfo.outfitID}%${platform}`)
                     .setLabel(i18n.__({phrase: 'View outfit', locale: locale}))
-                    .setStyle('PRIMARY')
+                    .setStyle(ButtonStyle.Primary)
             );
         }
 
         // Top Weapon, Auraxium medals
         if(cInfo.stats){
             if(cInfo.topWeaponName != "Error"){
-                resEmbed.addField(i18n.__({phrase: 'Top Weapon (kills)', locale: locale}), cInfo.topWeaponName+" ("+localeNumber(cInfo.mostKills, locale)+")", true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Top Weapon (kills)', locale: locale}), value: cInfo.topWeaponName+" ("+localeNumber(cInfo.mostKills, locale)+")", inline: true});
             }
             if(cInfo.auraxCount != "Error"){
-                resEmbed.addField(i18n.__({phrase: 'Auraxium Medals', locale: locale}), `${cInfo.auraxCount}`, true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Auraxium Medals', locale: locale}), value: `${cInfo.auraxCount}`, inline: true});
             }
         }
 
@@ -551,8 +554,8 @@ module.exports = {
                     className = i18n.__({phrase: 'MAX', locale: locale});
                     break;
             }
-            resEmbed.addField(i18n.__({phrase: 'Most Played Class (time)', locale: locale}), 
-            `${className} (${i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: localeNumber(classHours, locale), minute: classMinutes})})`, true);
+            resEmbed.addFields({name: i18n.__({phrase: 'Most Played Class (time)', locale: locale}), value:
+            `${className} (${i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: localeNumber(classHours, locale), minute: classMinutes})})`, inline: true});
         }
 
         // Favorite vehicle
@@ -561,8 +564,8 @@ module.exports = {
             const vehicleMinutes = Math.floor(cInfo.topVehicleTime/60 - vehicleHours*60);
             try{
                 let vehicleName = await getVehicleName(cInfo.favoriteVehicle, platform);
-                resEmbed.addField(i18n.__({phrase: 'Most Played Vehicle (time)', locale: locale}), 
-                `${i18n.__({phrase: vehicleName, locale: locale})} (${i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: localeNumber(vehicleHours, locale), minute: vehicleMinutes})})`, true);
+                resEmbed.addFields({name: i18n.__({phrase: 'Most Played Vehicle (time)', locale: locale}), value:
+                `${i18n.__({phrase: vehicleName, locale: locale})} (${i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: localeNumber(vehicleHours, locale), minute: vehicleMinutes})})`, inline: true});
             }
             catch(err){
                 //Fail silently
@@ -585,18 +588,20 @@ module.exports = {
         if(cInfo.time == 0){
             throw i18n.__({phrase: 'No stats in this time period', locale: locale});
         }
-        const resEmbed = new Discord.MessageEmbed();
+        const resEmbed = new EmbedBuilder();
         resEmbed.setTitle(cInfo.name);
         resEmbed.setDescription(i18n.__mf({phrase: '{day} day stats ending <t{end}d>', locale: locale}, {day: days, end: `:${cInfo.lastSave}:`}));
         resEmbed.setColor(faction(cInfo.faction).color);
-        resEmbed.addField(i18n.__({phrase: 'Score (SPM)', locale: locale}), `${cInfo.score.toLocaleString(locale)} (${localeNumber(cInfo.score/(cInfo.time/60), locale)})`, true);
+        resEmbed.addFields({name: i18n.__({phrase: 'Score (SPM)', locale: locale}), value: `${cInfo.score.toLocaleString(locale)} (${localeNumber(cInfo.score/(cInfo.time/60), locale)})`, inline: true});
         const hours = Math.floor(cInfo.time/60/60);
         const minutes = Math.floor(cInfo.time/60 - hours*60);
-        resEmbed.addField(i18n.__({phrase: 'Playtime', locale: locale}), i18n.__mf({phrase: "{hour} hours, {minute} minutes", locale: locale}, {hour: localeNumber(hours, locale), minute: minutes}), true);
-        resEmbed.addField(i18n.__({phrase: 'Certs Gained', locale: locale}), cInfo.certs.toLocaleString(locale), true);
-        resEmbed.addField(i18n.__({phrase: 'K/D', locale: locale}), localeNumber(cInfo.kills/cInfo.deaths, locale), true);
-        resEmbed.addField(i18n.__({phrase: 'K-D Diff', locale: locale}), `${(cInfo.kills).toLocaleString(locale)} - ${(cInfo.deaths).toLocaleString(locale)} = ${(cInfo.kills-cInfo.deaths).toLocaleString(locale, {signDisplay: "exceptZero"})}`, true);
-        resEmbed.addField(i18n.__({phrase: 'KPM', locale: locale}), localeNumber(cInfo.kills/(cInfo.time/60), locale), true);
+        resEmbed.addFields([
+            {name: i18n.__({phrase: 'Playtime', locale: locale}), value: i18n.__mf({phrase: "{hour} hours, {minute} minutes", locale: locale}, {hour: localeNumber(hours, locale), minute: minutes}), inline: true},
+            {name: i18n.__({phrase: 'Certs Gained', locale: locale}), value: cInfo.certs.toLocaleString(locale), inline: true},
+            {name: i18n.__({phrase: 'K/D', locale: locale}), value: localeNumber(cInfo.kills/cInfo.deaths, locale), inline: true},
+            {name: i18n.__({phrase: 'K-D Diff', locale: locale}), value: `${(cInfo.kills).toLocaleString(locale)} - ${(cInfo.deaths).toLocaleString(locale)} = ${(cInfo.kills-cInfo.deaths).toLocaleString(locale, {signDisplay: "exceptZero"})}`, inline: true},
+            {name: i18n.__({phrase: 'KPM', locale: locale}), value: localeNumber(cInfo.kills/(cInfo.time/60), locale), inline: true}
+        ]);
         return resEmbed;     
     },
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -9,7 +9,7 @@
  * @typedef {import('discord.js').Channel} discord.Channel
 */
 
-const {MessageEmbed} = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const messageHandler = require('./messageHandler.js');
 const {getPopulation} = require('./population.js');
 const {alertInfo, popLevels} = require('./alerts.js');
@@ -26,7 +26,7 @@ const {serverNames, serverIDs, servers, continents, faction} = require('./utils.
  * @returns the server dashboard embed
  */
 const serverStatus = async function(serverID, pgClient){
-	let resEmbed = new MessageEmbed();
+	const resEmbed = new EmbedBuilder();
 	resEmbed.setTitle(`${serverNames[serverID]} Dashboard`);
 
 	// Population
@@ -41,7 +41,7 @@ const serverStatus = async function(serverID, pgClient){
 	\n<:NC:818767043138027580> **NC**: ${population.nc}  |  ${ncPc}%\
 	\n<:TR:818988588049629256> **TR**: ${population.tr}  |  ${trPc}%\
 	\n<:NS:819511690726866986> **NSO**: ${population.ns}  |  ${nsPc}%`
-	resEmbed.addField(`Population - ${totalPop}`, populationField, true);
+	resEmbed.addFields({name: `Population - ${totalPop}`, value: populationField, inline: true});
 
 	// Territory
 	const territory = await territoryInfo(serverID);
@@ -84,7 +84,7 @@ const serverStatus = async function(serverID, pgClient){
 		}
 	}
 
-	resEmbed.addField("Territory", territoryField, true);
+	resEmbed.addFields({name: "Territory", value: territoryField, inline: true});
 
 	// Alerts
 	try{
@@ -94,10 +94,10 @@ const serverStatus = async function(serverID, pgClient){
 			alertField += `**[${alert.name}](https://ps2alerts.com/alert/${alert.instanceId}?utm_source=auraxis-bot&utm_medium=discord&utm_campaign=partners)**\
 			\n${alert.description}\nStarted at <t:${alert.timeStart}:t>\nEnds <t:${alert.timeEnd}:R>\nPopulation: ${popLevels[alert.bracket]}\n\n`;
 		}
-		resEmbed.addField("Alerts", alertField, true);
+		resEmbed.addFields({name: "Alerts", value: alertField, inline: true});
 	}
 	catch(err){
-		resEmbed.addField("Alerts", "No active alerts", true);
+		resEmbed.addFields({name: "Alerts", value: "No active alerts", inline: true});
 	}
 	resEmbed.setTimestamp();
 	resEmbed.setFooter({text: "Updated every 5 minutes • Population from Fisu • Alerts from PS2Alerts"});
@@ -115,7 +115,7 @@ const serverStatus = async function(serverID, pgClient){
  */
 const outfitStatus = async function(outfitID, platform, pgClient){
 	const oInfo = await onlineInfo("", platform, outfitID);
-	let resEmbed = new MessageEmbed();
+	const resEmbed = new EmbedBuilder();
 	if(oInfo.alias != ""){
 		resEmbed.setTitle(`[${oInfo.alias}] ${oInfo.name}`);
 		if(platform == 'ps2:v2'){
@@ -135,17 +135,17 @@ const outfitStatus = async function(outfitID, platform, pgClient){
 	resEmbed.setColor(faction(oInfo.faction).color);
 
 	if(oInfo.onlineCount === -1){
-		resEmbed.addField("Online member count unavailable", "-");
+		resEmbed.addFields({name: "Online member count unavailable", value: "-"});
 		resEmbed.setDescription(`?/${oInfo.memberCount} online`);
 	}
 	else{
 		for(let i = 0; i < 8; i++){
 			if(oInfo.onlineMembers[i].length > 0){
 				if(totalLength(oInfo.onlineMembers[i]) <= 1024){
-					resEmbed.addField(oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", `${oInfo.onlineMembers[i]}`.replace(/,/g, '\n'), true);
+					resEmbed.addFields({name: oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", value: `${oInfo.onlineMembers[i]}`.replace(/,/g, '\n'), inline: true});
 				}
 				else{
-					resEmbed.addField(oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", "Too many to display", true);
+					resEmbed.addFields({name: oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", value: "Too many to display", inline: true});
 				}
 			}
 		}
@@ -178,10 +178,12 @@ const outfitStatus = async function(outfitID, platform, pgClient){
 		}
 	}
 	if((auraxium + synthium + polystellarite) > 0){ //Recognized bases are owned
-		resEmbed.addField('Bases owned', `${ownedNames}`.replace(/,/g, '\n'));
-		resEmbed.addField('<:Auraxium:818766792376713249>', `+${auraxium/5}/min`, true);
-		resEmbed.addField('<:Synthium:818766858865475584>', `+${synthium/5}/min`, true);
-		resEmbed.addField('<:Polystellarite:818766888238448661>', `+${polystellarite/5}/min`, true);
+		resEmbed.addFields([
+			{name: 'Bases owned', value: `${ownedNames}`.replace(/,/g, '\n')},
+			{name: '<:Auraxium:818766792376713249>', value: `+${auraxium/5}/min`, inline: true},
+			{name: '<:Synthium:818766858865475584>', value: `+${synthium/5}/min`, inline: true},
+			{name: '<:Polystellarite:818766888238448661>', value: `+${polystellarite/5}/min`, inline: true}
+		]);
 	}
 
 	resEmbed.setTimestamp();

--- a/directives.js
+++ b/directives.js
@@ -4,7 +4,8 @@
  */
 
 const {censusRequest, faction} = require('./utils.js');
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder, MessageActionRow: ActionRowBuilder, MessageButton: ButtonBuilder} = require('discord.js');
+const { ButtonStyle } = require('discord-api-types/v10');
 const directives = require('./static/directives.json');
 const i18n = require('i18n');
 
@@ -50,7 +51,7 @@ module.exports = {
 	 */
 	directives: async function(cName, platform, expanded=false, locale="en-US"){
 		const directiveList = await getDirectiveList(cName.toLowerCase(), platform, locale);
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		resEmbed.setTitle(i18n.__mf({phrase: "{name} Directives", locale: locale}, {name: directiveList.name}));
 		let textList = "";
 		let remaining = directiveList.directives.length;
@@ -98,12 +99,12 @@ module.exports = {
 			resEmbed.setURL(`https://ps4eu.ps2.fisu.pw/directive/?name=${directiveList[0]}`);
 		}
 		if(remaining > 0){
-			const row = new Discord.MessageActionRow()
+			const row = new ActionRowBuilder()
 			row.addComponents(
-				new Discord.MessageButton()
+				new ButtonBuilder()
 					.setCustomId(`directives%${directiveList.name}%${platform}`)
 					.setLabel(i18n.__({phrase: "View all", locale: locale}))
-					.setStyle('PRIMARY')
+					.setStyle(ButtonStyle.Primary)
 			);
 			return [resEmbed, [row]];
 		}

--- a/implant.js
+++ b/implant.js
@@ -2,7 +2,7 @@
  * Search up implant information
  * @module implant
  */
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js'); 
 const implantsJSON = require('./static/implants.json');
 const {badQuery} = require('./utils.js');
 
@@ -67,18 +67,20 @@ module.exports = {
 		
 		const iInfo = await implantInfo(name);
 
-		const resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		resEmbed.setTitle(iInfo.name);
 		resEmbed.setThumbnail(`http://census.daybreakgames.com/files/ps2/images/static/'${iInfo.image}.png`);
 		if(iInfo.desc !== undefined){
-			resEmbed.addField("Description", iInfo.desc);
+			resEmbed.addFields({name: "Description", value: iInfo.desc});
 		}
 		else{
-			resEmbed.addField("Rank 1", iInfo["1"]);
-			resEmbed.addField("Rank 2", iInfo["2"]);
-			resEmbed.addField("Rank 3", iInfo["3"]);
-			resEmbed.addField("Rank 4", iInfo["4"]);
-			resEmbed.addField("Rank 5", iInfo["5"]);
+			resEmbed.addFields([
+				{name: "Rank 1", value: iInfo["1"]},
+				{name: "Rank 2", value: iInfo["2"]},
+				{name: "Rank 3", value: iInfo["3"]},
+				{name: "Rank 4", value: iInfo["4"]},
+				{name: "Rank 5", value: iInfo["5"]}
+			]);
 		}
 
 		return resEmbed;

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -4,7 +4,7 @@
  */
 
 const {censusRequest, serverIDs, serverNames} = require('./utils.js');
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const i18n = require('i18n');
 
 /**
@@ -43,7 +43,7 @@ module.exports = {
 		}
 		const data = await censusRequest(platform, 'leaderboard_list', constructExtension(name, period, serverIDs[server], limit));
 
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		if(server == undefined){
 			resEmbed.setTitle(i18n.__mf({phrase: "{period} {type} leaderboard", locale: locale}, 
 			{period: i18n.__({phrase: period, locale: locale}), type: i18n.__({phrase: name, locale: locale})}));

--- a/main.js
+++ b/main.js
@@ -5,6 +5,8 @@
 
 // Import the discord.js module
 const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
+const { GatewayIntentBits } = require('discord-api-types/v10');
 
 //PostgreSQL connection
 const pg = require('pg');
@@ -66,9 +68,9 @@ if(typeof(process.env.TWITTER_CONSUMER_KEY) !== 'undefined'){
 }
 
 const intentsList = [
-	Discord.Intents.FLAGS.GUILD_MESSAGES,
-	Discord.Intents.FLAGS.DIRECT_MESSAGES,
-	Discord.Intents.FLAGS.GUILDS
+	GatewayIntentBits.GuildMessages,
+	GatewayIntentBits.DirectMessages,
+	GatewayIntentBits.Guilds
 ]
 
 const client = new Discord.Client({intents: intentsList, allowedMentions: {parse: ['roles']}, partials: ['CHANNEL']});
@@ -163,17 +165,17 @@ client.on('interactionCreate', async interaction => {
 
 			case 'help':
 				const locale = interaction.locale;
-				let helpEmbed = new Discord.MessageEmbed();
+				const helpEmbed = new EmbedBuilder();
 				helpEmbed.setTitle("Auraxis bot");
 				helpEmbed.setColor("BLUE");
-				helpEmbed.addField(i18n.__({phrase: "Commands", locale: locale}), listOfCommands);
+				helpEmbed.addFields({name: i18n.__({phrase: "Commands", locale: locale}), value: listOfCommands});
 				const links = `\
 				\n[${i18n.__({phrase: "GitHub page & FAQ", locale: locale})}](https://github.com/RemainNA/auraxis-bot)\
 				\n[${i18n.__({phrase: "Support server", locale: locale})}](https://discord.gg/Kf5P6Ut)\
 				\n[${i18n.__({phrase: "Invite bot", locale: locale})}](https://discord.com/api/oauth2/authorize?client_id=437756856774033408&permissions=1330192&scope=bot%20applications.commands)\
 				\n[${i18n.__({phrase: "Donate on Ko-fi", locale: locale})}](https://ko-fi.com/remainna)\
 				\n[${i18n.__({phrase: "Translate on Crowdin", locale: locale})}](https://crowdin.com/project/auraxis-bot)`
-				helpEmbed.addField(i18n.__({phrase: "Links", locale: locale}), links);
+				helpEmbed.addFields({name: i18n.__({phrase: "Links", locale: locale}), value: links});
 				helpEmbed.setFooter({text: i18n.__({phrase: "<> = Optional, [] = Required", locale: locale})});
 				await interaction.reply({embeds: [helpEmbed]});
 				break;

--- a/messageHandler.js
+++ b/messageHandler.js
@@ -2,6 +2,7 @@
  * This file defines methods for sending messages, and handles errors that occur in that process.
  * @module messageHandler
  */
+const { PermissionFlagsBits } = require('discord-api-types/v10');
 /**
  * @typedef {import('discord.js').TextChannel} discord.Channel
  */
@@ -16,7 +17,7 @@ module.exports = {
      */
     send: async function(channel, message, context="default", embed=false){
         let res = -1;
-        if(embed && channel.type != 'DM' && !channel.permissionsFor(channel.guild.me).has('EMBED_LINKS')){
+        if(embed && channel.type != 'DM' && !channel.permissionsFor(channel.guild.me).has(PermissionFlagsBits.EmbedLinks)){
             channel.send('Please grant the "Embed Links" permission to use this command').then(function(result){
                 //message successfully sent, no action needed.
             }, function(err){

--- a/online.js
+++ b/online.js
@@ -2,8 +2,7 @@
  * Handles the `/online` command
  * @module online
  */
-
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const { badQuery, censusRequest, faction} = require('./utils.js');
 const i18n = require('i18n');
 
@@ -109,7 +108,7 @@ module.exports = {
 		}
 
 		let oInfo = await onlineInfo(oTag, platform, outfitID, locale);
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 
 		resEmbed.setTitle(oInfo.name);
 		resEmbed.setDescription(oInfo.alias+"\n"+i18n.__mf({phrase: "{online}/{total} online", locale: locale}, 
@@ -126,7 +125,7 @@ module.exports = {
 		}
 		resEmbed.setColor(faction(oInfo.faction).color)
 		if(oInfo.onlineCount === -1){
-			resEmbed.addField(i18n.__({phrase: "Online member count unavailable", locale: locale}), "-", true);
+			resEmbed.addFields({name: i18n.__({phrase: "Online member count unavailable", locale: locale}), value: "-", inline: true});
 			resEmbed.setDescription(oInfo.alias+"\n"+"?/"+oInfo.memberCount+" online");
 
 			return resEmbed;
@@ -134,10 +133,10 @@ module.exports = {
 		for(let i = 0; i < 8; i++){
 			if(oInfo.onlineMembers[i].length > 0){
 				if(totalLength(oInfo.onlineMembers[i]) <= 1024){
-					resEmbed.addField(oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", `${oInfo.onlineMembers[i]}`.replace(/,/g, '\n'), true);
+					resEmbed.addFields({name: oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", value: `${oInfo.onlineMembers[i]}`.replace(/,/g, '\n'), inline: true});
 				}
 				else{
-					resEmbed.addField(oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", i18n.__({phrase: "Too many to display", locale: locale}), true);
+					resEmbed.addFields({name: oInfo.rankNames[i]+" ("+oInfo.onlineMembers[i].length+")", value: i18n.__({phrase: "Too many to display", locale: locale}), inline: true});
 				}
 			}
 		}

--- a/openContinents.js
+++ b/openContinents.js
@@ -11,7 +11,7 @@ const {territoryInfo} = require('./territory.js');
 const {serverIDs, serverNames, servers, continents} = require('./utils.js');
 const {send} = require('./messageHandler.js');
 const {unsubscribeAll} = require('./subscriptions.js');
-const {Permissions} = require('discord.js');
+const { PermissionFlagsBits } = require('discord-api-types/v10');
 const trackers = require('./trackers.js');
 
 /**
@@ -38,7 +38,7 @@ const notifyUnlock = async function(cont, server, channelID, pgClient, discordCl
 	try{
 		const channel = await discordClient.channels.fetch(channelID);
 		if(typeof(channel.guild) !== 'undefined'){
-			if(channel.permissionsFor(channel.guild.me).has([Permissions.FLAGS.SEND_MESSAGES, Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.EMBED_LINKS])){
+			if(channel.permissionsFor(channel.guild.me).has([PermissionFlagsBits.SendMessages, PermissionFlagsBits.ViewChannel, PermissionFlagsBits.EmbedLinks])){
 				await send(channel, `${cont} on ${server} is now open!`, "Continent unlock");
 			}
 			else{

--- a/outfit.js
+++ b/outfit.js
@@ -3,7 +3,8 @@
  * @module outfit
  * @typedef { import('pg').Client} pg.Client
  */
-const Discord = require('discord.js');
+const { MessageEmbed: EmbedBuilder, MessageActionRow: ActionRowBuilder, MessageButton: ButtonBuilder } = require('discord.js');
+const { ButtonStyle } = require('discord-api-types/v10');
 const { serverNames, badQuery, censusRequest, localeNumber, faction } = require('./utils.js');
 const bases = require('./static/bases.json');
 const i18n = require('i18n');
@@ -154,7 +155,7 @@ module.exports = {
 		const oInfo = await basicInfo(oTag, platform, oID);
 		const oBases = await ownedBases(oInfo.outfitID, oInfo.worldId, pgClient);
 
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 
 		resEmbed.setTitle(oInfo.name);
 		if(oInfo.alias != ""){
@@ -169,29 +170,33 @@ module.exports = {
 				resEmbed.setURL('http://ps4eu.ps2.fisu.pw/outfit/?name='+oInfo.alias);
 			}
 		}
-		resEmbed.addField(i18n.__({phrase: "Founded", locale: locale}), `<t:${oInfo.timeCreated}:D>`, true);
-		resEmbed.addField(i18n.__({phrase: "Members", locale: locale}), localeNumber(oInfo.memberCount, locale), true);
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Founded", locale: locale}), value: `<t:${oInfo.timeCreated}:D>`, inline: true},
+			{name: i18n.__({phrase: "Members", locale: locale}), value: localeNumber(oInfo.memberCount, locale), inline: true}
+		]);
 		const dayPc = localeNumber((oInfo.onlineDay/oInfo.memberCount)*100, locale);
 		const weekPc = localeNumber((oInfo.onlineWeek/oInfo.memberCount)*100, locale);
 		const monthPc = localeNumber((oInfo.onlineMonth/oInfo.memberCount)*100, locale);
-		resEmbed.addField(i18n.__({phrase: "Online", locale: locale}), `${oInfo.onlineMembers}`, true);
-		resEmbed.addField(i18n.__({phrase: "Last day", locale: locale}), localeNumber(oInfo.onlineDay, locale)+" ("+dayPc+"%)", true);
-		resEmbed.addField(i18n.__({phrase: "Last week", locale: locale}), localeNumber(oInfo.onlineWeek, locale)+" ("+weekPc+"%)", true);
-		resEmbed.addField(i18n.__({phrase: "Last month", locale: locale}), localeNumber(oInfo.onlineMonth, locale)+" ("+monthPc+"%)", true);
-		resEmbed.addField(i18n.__({phrase: "Server", locale: locale}), i18n.__({phrase: serverNames[Number(oInfo.worldId)], locale: locale}), true);
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Online", locale: locale}), value: `${oInfo.onlineMembers}`, inline: true},
+			{name: i18n.__({phrase: "Last day", locale: locale}), value: localeNumber(oInfo.onlineDay, locale)+" ("+dayPc+"%)", inline: true},
+			{name: i18n.__({phrase: "Last week", locale: locale}), value: localeNumber(oInfo.onlineWeek, locale)+" ("+weekPc+"%)", inline: true},
+			{name: i18n.__({phrase: "Last month", locale: locale}), value: localeNumber(oInfo.onlineMonth, locale)+" ("+monthPc+"%)", inline: true},
+			{name: i18n.__({phrase: "Server", locale: locale}), value: i18n.__({phrase: serverNames[Number(oInfo.worldId)], locale: locale}), inline: true}
+		]);
 
 		const factionInfo = faction(oInfo.faction);
-		resEmbed.addField(i18n.__({phrase: "Faction", locale: locale}), `${factionInfo.decal} ${i18n.__({phrase: factionInfo.initial, locale: locale})}`, true);
+		resEmbed.addFields({name: i18n.__({phrase: "Faction", locale: locale}), value: `${factionInfo.decal} ${i18n.__({phrase: factionInfo.initial, locale: locale})}`, inline: true});
 		resEmbed.setColor(factionInfo.color);
 
 		if(platform == "ps2:v2"){
-			resEmbed.addField(i18n.__({phrase: 'Owner', locale: locale}), "["+oInfo.owner+"]("+"https://ps2.fisu.pw/player/?name="+oInfo.owner+")", true);
+			resEmbed.addFields({name: i18n.__({phrase: 'Owner', locale: locale}), value:"["+oInfo.owner+"]("+"https://ps2.fisu.pw/player/?name="+oInfo.owner+")", inline: true});
 		}
 		else if(platform == "ps2ps4us:v2"){
-			resEmbed.addField(i18n.__({phrase: 'Owner', locale: locale}), "["+oInfo.owner+"]("+"https://ps4us.ps2.fisu.pw/player/?name="+oInfo.owner+")", true);
+			resEmbed.addFields({name: i18n.__({phrase: 'Owner', locale: locale}), value:"["+oInfo.owner+"]("+"https://ps4us.ps2.fisu.pw/player/?name="+oInfo.owner+")", inline: true});
 		}
 		else if(platform == "ps2ps4eu:v2"){
-			resEmbed.addField(i18n.__({phrase: 'Owner', locale: locale}), "["+oInfo.owner+"]("+"https://ps4eu.ps2.fisu.pw/player/?name="+oInfo.owner+")", true);
+			resEmbed.addFields({name: i18n.__({phrase: 'Owner', locale: locale}), value:"["+oInfo.owner+"]("+"https://ps4eu.ps2.fisu.pw/player/?name="+oInfo.owner+")", inline: true});
 		}
 		let auraxium = 0;
 		let synthium = 0;
@@ -237,16 +242,18 @@ module.exports = {
 			}
 		}
 		if((auraxium + synthium + polystellarite) > 0){ //Recognized bases are owned
-			resEmbed.addField('<:Auraxium:818766792376713249>', `+${auraxium/5}/min`, true);
-			resEmbed.addField('<:Synthium:818766858865475584>', `+${synthium/5}/min`, true);
-			resEmbed.addField('<:Polystellarite:818766888238448661>', `+${polystellarite/5}/min`, true);
-			resEmbed.addField(i18n.__({phrase: 'Bases owned', locale: locale}), `${ownedNames}`.replace(/,/g, '\n'));
+			resEmbed.addFields([
+				{name: '<:Auraxium:818766792376713249>', value: `+${auraxium/5}/min`, inline: true},
+				{name: '<:Synthium:818766858865475584>', value: `+${synthium/5}/min`, inline: true},
+				{name: '<:Polystellarite:818766888238448661>', value: `+${polystellarite/5}/min`, inline: true},
+				{name: i18n.__({phrase: 'Bases owned', locale: locale}), value: `${ownedNames}`.replace(/,/g, '\n')}
+			]);
 		}
 
-		const row = new Discord.MessageActionRow();
+		const row = new ActionRowBuilder();
 		row.addComponents(
-			new Discord.MessageButton()
-				.setStyle('PRIMARY')
+			new ButtonBuilder()
+				.setStyle(ButtonStyle.Primary)
 				.setLabel(i18n.__({phrase: 'View online', locale: locale}))
 				.setCustomId(`online%${oInfo.outfitID}%${platform}`)
 		);
@@ -254,12 +261,12 @@ module.exports = {
 			const now = Math.round(Date.now() / 1000);
 
 			row.addComponents(
-				new Discord.MessageButton()
-					.setStyle('LINK')
+				new ButtonBuilder()
+					.setStyle(ButtonStyle.Link)
 					.setURL(generateReport([oInfo.outfitID], now-3600, now))
 					.setLabel(i18n.__({phrase: 'Past 1 hour report', locale: locale})),
-				new Discord.MessageButton()
-					.setStyle('LINK')
+				new ButtonBuilder()
+					.setStyle(ButtonStyle.Link)
 					.setURL(generateReport([oInfo.outfitID], now-7200, now))
 					.setLabel(i18n.__({phrase: 'Past 2 hour report', locale: locale}))
 			);

--- a/population.js
+++ b/population.js
@@ -3,7 +3,7 @@
  * @module population
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const got = require('got')
 const {servers, serverIDs, serverNames, localeNumber} = require('./utils.js');
 const i18n = require('i18n');
@@ -82,7 +82,7 @@ module.exports = {
 	lookup: async function(server, locale="en-US"){
 
 		if(server == 'all'){
-			let resEmbed = new Discord.MessageEmbed();
+			const resEmbed = new EmbedBuilder();
 			let total = 0;
 			//Construct an array of promises and await them all in parallel
 			const results = await Promise.all(Array.from(servers, x=> getPopulation(serverIDs[x])))
@@ -98,7 +98,7 @@ module.exports = {
 				\n<:TR:818988588049629256> **${i18n.__({phrase: 'TR', locale: locale})}**: ${pop.tr}  |  ${trPc}%\
 				\n<:NS:819511690726866986> **${i18n.__({phrase: 'NSO', locale: locale})}**: ${pop.ns}  |  ${nsPc}%`
 				const populationTitle = i18n.__mf({phrase: "{server} population - {total}", locale: locale}, {server: i18n.__({phrase: serverNames[pop.world], locale: locale}), total: serverTotal})
-				resEmbed.addField(populationTitle, populationField, true);
+				resEmbed.addFields({name: populationTitle, value: populationField, inline: true});
 				total += serverTotal;
 			}
 			resEmbed.setTitle(i18n.__mf({phrase: "Total population - {total}", locale: locale}, {total: total.toLocaleString(locale)}));
@@ -111,7 +111,7 @@ module.exports = {
 			const normalized = serverNames[serverID];
 			const res = await getPopulation(serverID);
 
-			let sendEmbed = new Discord.MessageEmbed();
+			const sendEmbed = new EmbedBuilder();
 			let total = Number(res.vs) + Number(res.nc) + Number(res.tr) + Number(res.ns);
 			sendEmbed.setTitle(i18n.__mf({phrase: "{server} population - {total}", locale: locale}, {server: i18n.__({phrase: normalized, locale: locale}), total: total.toLocaleString(locale)}));
 			total = Math.max(total, 1);

--- a/preASP.js
+++ b/preASP.js
@@ -3,7 +3,7 @@
  * @module preASP
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const { censusRequest, badQuery, faction } = require('./utils.js');
 const i18n = require('i18n');
 
@@ -87,7 +87,7 @@ module.exports = {
 		}
 		let cInfo = await basicInfo(cName, platform, locale);
 
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		resEmbed.setColor(faction(cInfo.faction).color);
 		resEmbed.setTitle(cInfo.name);
 		resEmbed.setDescription(`${i18n.__({phrase: "BR pre ASP", locale: locale})}: ${cInfo.preBR}`);
@@ -97,10 +97,12 @@ module.exports = {
 		else{
 			cInfo.unlocks = cInfo.unlocks.substring(0,(cInfo.unlocks.length-6));
 		}
-		resEmbed.addField(i18n.__({phrase: "Available Points", locale: locale}), `${cInfo.availableTokens}`);
-		resEmbed.addField(i18n.__({phrase: "ASP Skills", locale: locale}), cInfo.unlocks);
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Available Points", locale: locale}), value: `${cInfo.availableTokens}`},
+			{name: i18n.__({phrase: "ASP Skills", locale: locale}), value: cInfo.unlocks}
+		]);
 		if(cInfo.unlocksContinued != ""){
-			resEmbed.addField(i18n.__({phrase: "ASP Skills Continued", locale: locale}), cInfo.unlocksContinued.substring(0,(cInfo.unlocksContinued.length-6)));
+			resEmbed.addFields({name: i18n.__({phrase: "ASP Skills Continued", locale: locale}), value: cInfo.unlocksContinued.substring(0,(cInfo.unlocksContinued.length-6))});
 		}
 		resEmbed.setThumbnail("http://census.daybreakgames.com/files/ps2/images/static/88688.png");
 

--- a/registerCommands.js
+++ b/registerCommands.js
@@ -13,7 +13,7 @@ i18n.configure({
 	defaultLocale: 'en-us',
 	updateFiles: false,
 	objectNotation: true
-})
+});
 
 /**
  * all server options
@@ -21,7 +21,7 @@ i18n.configure({
 const allOption = {
 	name: 'All',
 	value: 'all'
-}
+};
 
 /**
  * Different platforms PS2 servers are on
@@ -39,7 +39,7 @@ const platforms = [
 		name: 'PS4 EU',
 		value: 'ps2ps4eu:v2'
 	}
-]
+];
 
 /**
  * All servers excpet for Jaeger
@@ -73,12 +73,12 @@ const serversNoJaeger = [
 		name: "Ceres",
 		value: "ceres"
 	}
-]
+];
 
 /**
  * All servers
  */
-const servers = serversNoJaeger.concat([{name:"Jaeger", value: "jaeger"}]);
+const servers = serversNoJaeger.concat([{ name: "Jaeger", value: "jaeger" }]);
 
 /**
  * All possible commands
@@ -433,11 +433,11 @@ const data = [
 				description: 'Automatically delete alerts and outfit activity notifications',
 				type: '1',
 				options: [{
-						name: 'setting',
-						description: 'Delete notifications in this channel',
-						type: '3',
-						required: true,
-						choices: [
+					name: 'setting',
+					description: 'Delete notifications in this channel',
+					type: '3',
+					required: true,
+					choices: [
 						{
 							name: 'Enable',
 							value: 'enable'
@@ -622,7 +622,7 @@ const data = [
 				type: '3',
 				description: 'Type of tracker channel',
 				required: true,
-				choices:[
+				choices: [
 					{
 						name: 'Population',
 						value: 'population'
@@ -633,32 +633,32 @@ const data = [
 					}
 				]
 			}]
+		},
+		{
+			name: "outfit",
+			description: "Create an automatically updating voice channel displaying outfit online count",
+			type: '1',
+			options: [{
+				name: 'tag',
+				type: '3',
+				description: 'Outfit tag',
+				required: true
 			},
 			{
-				name: "outfit",
-				description: "Create an automatically updating voice channel displaying outfit online count",
-				type: '1',
-				options: [{
-					name: 'tag',
-					type: '3',
-					description: 'Outfit tag',
-					required: true
-				},
-				{
-					name: 'show-faction',
-					type: '5',
-					description: 'Display a faction indicator in channel name? ex: 🟣/🔵/🔴/⚪',
-					required: true
-				},
-				{
-					name: 'platform',
-					type: '3',
-					description: "Which platform is the outfit on?  Defaults to PC",
-					required: false,
-					choices: platforms
-				}
-				]
+				name: 'show-faction',
+				type: '5',
+				description: 'Display a faction indicator in channel name? ex: 🟣/🔵/🔴/⚪',
+				required: true
+			},
+			{
+				name: 'platform',
+				type: '3',
+				description: "Which platform is the outfit on?  Defaults to PC",
+				required: false,
+				choices: platforms
 			}
+			]
+		}
 		]
 	},
 	{
@@ -778,19 +778,19 @@ const data = [
 			choices: platforms
 		}]
 	}
-]
+];
 
-const rest = new REST({version: '10'}).setToken(process.env.token);
+const rest = new REST({ version: '10' }).setToken(process.env.token);
 
 (async () => {
-	try{
+	try {
 		await rest.put(
 			Routes.applicationCommands(process.env.clientID),
 			{ body: data },
 		);
 		console.log('done');
 	}
-	catch(err){
-		console.log(err)
+	catch (err) {
+		console.log(err);
 	}
-}) ();
+})();

--- a/registerCommands.js
+++ b/registerCommands.js
@@ -3,7 +3,7 @@
  * @module registerCommands
  */
 const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v9');
+const { Routes } = require('discord-api-types/v10');
 
 require('dotenv').config();
 
@@ -780,7 +780,7 @@ const data = [
 	}
 ]
 
-const rest = new REST({ version: '9'}).setToken(process.env.token);
+const rest = new REST({version: '10'}).setToken(process.env.token);
 
 (async () => {
 	try{

--- a/stats.js
+++ b/stats.js
@@ -3,7 +3,7 @@
  * @module stats
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const weaponsJSON = require('./static/weapons.json');
 const sanction = require('./static/sanction.json');
 const { badQuery, censusRequest, localeNumber, faction } = require('./utils.js');
@@ -256,7 +256,7 @@ module.exports = {
 		}
 		wInfo.id = cInfo.weapon;
 
-		let resEmbed = new Discord.MessageEmbed();
+		let resEmbed = new EmbedBuilder();
 		resEmbed.setTitle(cInfo.name);
 		resEmbed.setDescription(`${wInfo.name} (${wInfo.category})`);
 		let totalKills = parseInt(cInfo.vsKills)+parseInt(cInfo.ncKills)+parseInt(cInfo.trKills);
@@ -269,17 +269,21 @@ module.exports = {
 		let hsr = totalHeadshots/totalKills;
 		let ahr = Math.floor(accuracy*hsr*10000);
 		let spm = cInfo.score/(cInfo.playTime/60);
-		resEmbed.addField(i18n.__({phrase: "Kills", locale: locale}), totalKills.toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "Deaths", locale: locale}), cInfo.deaths.toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "K/D", locale: locale}), localeNumber(totalKills/cInfo.deaths, locale), true);
-		resEmbed.addField(i18n.__({phrase: "Accuracy", locale: locale}), localeNumber(accuracy*100, locale)+"%", true);
-		totalHeadshots && resEmbed.addField(i18n.__({phrase: "HSR", locale: locale}), localeNumber(hsr*100, locale)+"%", true);
-		ahr && resEmbed.addField(i18n.__({phrase: "AHR Score", locale: locale}), `${ahr}`, true);
-		totalVehicleKills && resEmbed.addField(i18n.__({phrase: "Vehicle Kills", locale: locale}), totalVehicleKills.toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "Playtime", locale: locale}), hours+" hours, "+minutes+" minutes", true);
-		resEmbed.addField(i18n.__({phrase: "KPM", locale: locale}), localeNumber(totalKills/(cInfo.playTime/60), locale), true);
-		resEmbed.addField(i18n.__({phrase: "Avg Damage/Kill", locale: locale}), Math.floor(totalDamage/totalKills).toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "Score (SPM)", locale: locale}), cInfo.score.toLocaleString(locale)+" ("+localeNumber(spm, locale)+")", true);
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Kills", locale: locale}), value: totalKills.toLocaleString(locale), inline: true},
+			{name: i18n.__({phrase: "Deaths", locale: locale}), value: cInfo.deaths.toLocaleString(locale), inline: true},
+			{name: i18n.__({phrase: "K/D", locale: locale}), value: localeNumber(totalKills/cInfo.deaths, locale), inline: true},
+			{name: i18n.__({phrase: "Accuracy", locale: locale}), value: localeNumber(accuracy*100, locale)+"%", inline: true}
+		]);
+		totalHeadshots && resEmbed.addFields({name: i18n.__({phrase: "HSR", locale: locale}), value: localeNumber(hsr*100, locale)+"%", inline: true});
+		ahr && resEmbed.addFields({name: i18n.__({phrase: "AHR Score", locale: locale}), value: `${ahr}`, inline: true});
+		totalVehicleKills && resEmbed.addFields({name: i18n.__({phrase: "Vehicle Kills", locale: locale}), value: totalVehicleKills.toLocaleString(locale), inline: true});
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Playtime", locale: locale}), value: hours+" hours, "+minutes+" minutes", inline: true},
+			{name: i18n.__({phrase: "KPM", locale: locale}), value: localeNumber(totalKills/(cInfo.playTime/60), locale), inline: true},
+			{name: i18n.__({phrase: "Avg Damage/Kill", locale: locale}), value: Math.floor(totalDamage/totalKills).toLocaleString(locale), inline: true},
+			{name: i18n.__({phrase: "Score (SPM)", locale: locale}), value: cInfo.score.toLocaleString(locale)+" ("+localeNumber(spm, locale)+")", inline: true}
+		]);
 		resEmbed.setColor(faction(cInfo.faction).color)
 		if(wInfo.image_id != -1 && wInfo.image_id != undefined){
 			resEmbed.setThumbnail('http://census.daybreakgames.com/files/ps2/images/static/'+wInfo.image_id+'.png');

--- a/status.js
+++ b/status.js
@@ -3,7 +3,7 @@
  * @module status
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const { censusRequest } = require('./utils.js');
 const i18n = require('i18n');
 
@@ -49,10 +49,10 @@ module.exports = {
 	 */
 	servers: async function(locale="en-US"){
 		const status = await info();
-		const resEmbed = new Discord.MessageEmbed()
+		const resEmbed = new EmbedBuilder()
 			.setTitle(i18n.__({phrase: 'Server Status', locale: locale}));
 		for(const server in status){
-			resEmbed.addField(i18n.__({phrase: server, locale: locale}), i18n.__({phrase: status[server], locale: locale}), true);
+			resEmbed.addFields({name: i18n.__({phrase: server, locale: locale}), value: i18n.__({phrase: status[server], locale: locale}), inline: true});
 		}
 		resEmbed.setTimestamp();
 		return resEmbed;

--- a/subscriptionConfig.js
+++ b/subscriptionConfig.js
@@ -6,7 +6,7 @@
  * @typedef {import('pg').Client} pg.Client
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 
 /**
  * Get the status of alert subscriptions for a `continent`
@@ -61,7 +61,7 @@ module.exports = {
 				return "This channel currently has no subscriptions";
 			}
 			let row = res.rows[0];
-			let resEmbed = new Discord.MessageEmbed();
+			const resEmbed = new EmbedBuilder();
 			resEmbed.setTitle("Subscription config");
 			let alertStatus = "NB: If this channel is not subscribed to alerts you can ignore the following two sections\n";
 			alertStatus += getAlertStatus("Koltyr", row.koltyr)+"\n";
@@ -71,7 +71,7 @@ module.exports = {
 			alertStatus += getAlertStatus("Esamir", row.esamir)+"\n";
 			alertStatus += getAlertStatus("Oshur", row.oshur)+"\n";
 			alertStatus += getAlertStatus("Other", row.other);
-			resEmbed.addField("Continents", alertStatus);
+			resEmbed.addFields({name: "Continents", value: alertStatus});
 
 			let territoryStatus = "";
 			if(row.territory){
@@ -87,13 +87,13 @@ module.exports = {
 				territoryStatus += ":x: Non-territory alerts are not displayed" 
 			}
 
-			resEmbed.addField("Alert types", territoryStatus);
+			resEmbed.addFields({name: "Alert types", value: territoryStatus});
 
 			if(row.autodelete){
-				resEmbed.addField("Auto Delete", ":white_check_mark: Alert and outfit activity notifications are automatically deleted");
+				resEmbed.addFields({name: "Auto Delete", value: ":white_check_mark: Alert and outfit activity notifications are automatically deleted"});
 			}
 			else{
-				resEmbed.addField("Auto Delete", ":x: Alert and outfit activity notifications are not automatically deleted");
+				resEmbed.addFields({name: "Auto Delete", value: ":x: Alert and outfit activity notifications are not automatically deleted"});
 			}
 			resEmbed.setColor("BLUE");
 			return resEmbed;

--- a/subscriptions.js
+++ b/subscriptions.js
@@ -9,7 +9,7 @@
 
 const config = require('./subscriptionConfig.js');
 const { censusRequest, badQuery, faction } = require('./utils.js')
-const { Permissions } = require('discord.js');
+const { PermissionFlagsBits } = require('discord-api-types/v10');
 const i18n = require('i18n');
 
 /**
@@ -394,7 +394,7 @@ module.exports = {
         if(channel.isThread()){
             channel = interaction.channel.parent;
         }
-        if(!await channel.permissionsFor(user).has([Permissions.FLAGS.VIEW_CHANNEL, Permissions.FLAGS.SEND_MESSAGES])){
+        if(!await channel.permissionsFor(user).has([PermissionFlagsBits.ViewChannel, PermissionFlagsBits.SendMessages])){
             await interaction.followUp({
                 content: i18n.__({phrase: "insufficientPermissions", locale: locale})
             });

--- a/territory.js
+++ b/territory.js
@@ -6,7 +6,7 @@
  * @typedef {import('pg').Client} pg.Client
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const { serverNames, serverIDs, censusRequest, continents, localeNumber, faction } = require('./utils');
 const i18n = require('i18n');
 
@@ -177,7 +177,7 @@ module.exports = {
 
         const serverID = serverIDs[serverName];
         let terObj = await this.territoryInfo(serverID);
-        let resEmbed = new Discord.MessageEmbed();
+        const resEmbed = new EmbedBuilder();
         resEmbed.setTitle(i18n.__mf({phrase: "{continent} territory", locale: locale}, {continent: i18n.__({phrase: serverNames[serverID], locale: locale})}));
         resEmbed.setTimestamp();
         resEmbed.setURL(fisuTerritory(serverID));
@@ -193,14 +193,14 @@ module.exports = {
             const trPc = localeNumber((terObj[continent].tr/Total)*100, locale);
             const owningFaction = faction(terObj[continent].locked);
             if(terObj[continent].locked != -1){
-                resEmbed.addField(`${i18n.__({phrase: continent, locale: locale})} ${owningFaction.decal}`, i18n.__mf({phrase: "Locked {timestamp} ({relative})", locale: locale}, {timestamp: `<t:${timestamp}:t>`, relative: `<t:${timestamp}:R>`})+"\n"+continentBenefit(continent, locale));
+                resEmbed.addFields({name: `${i18n.__({phrase: continent, locale: locale})} ${owningFaction.decal}`, value: i18n.__mf({phrase: "Locked {timestamp} ({relative})", locale: locale}, {timestamp: `<t:${timestamp}:t>`, relative: `<t:${timestamp}:R>`})+"\n"+continentBenefit(continent, locale)});
             }
             else{
-                resEmbed.addField(i18n.__({phrase: continent, locale: locale}), `\
+                resEmbed.addFields({name: i18n.__({phrase: continent, locale: locale}), value: `\
                 \n${i18n.__mf({phrase: "Unlocked {timestamp} ({relative})", locale: locale}, {timestamp: `<t:${timestamp}:t>`, relative: `<t:${timestamp}:R>`})}\
                 \n<:VS:818766983918518272> **${i18n.__({phrase: "VS", locale: locale})}**: ${terObj[continent].vs}  |  ${vsPc}%\
                 \n<:NC:818767043138027580> **${i18n.__({phrase: "NC", locale: locale})}**: ${terObj[continent].nc}  |  ${ncPc}%\
-                \n<:TR:818988588049629256> **${i18n.__({phrase: "TR", locale: locale})}**: ${terObj[continent].tr}  |  ${trPc}%`);
+                \n<:TR:818988588049629256> **${i18n.__({phrase: "TR", locale: locale})}**: ${terObj[continent].tr}  |  ${trPc}%`});
             }
         }
 

--- a/unifiedWSListener.js
+++ b/unifiedWSListener.js
@@ -47,7 +47,7 @@ function listen(pgClient, discordClient){
         })
 
         pcClient.on('message', function incoming(data){
-            let parsed = JSON.parse(data);
+            const parsed = JSON.parse(data.toString());
             if(parsed.payload != null){
                 handler.router(parsed.payload, "ps2:v2", pgClient, discordClient);
             }
@@ -81,7 +81,7 @@ function listen(pgClient, discordClient){
         })
 
         usClient.on('message', function incoming(data){
-            let parsed = JSON.parse(data);
+            const parsed = JSON.parse(data.toString());
             if(parsed.payload != null){
                 handler.router(parsed.payload, "ps2ps4us:v2", pgClient, discordClient);
             }
@@ -115,7 +115,7 @@ function listen(pgClient, discordClient){
         })
 
         euClient.on('message', function incoming(data){
-            let parsed = JSON.parse(data);
+            const parsed = JSON.parse(data.toString());
             if(parsed.payload != null){
                 handler.router(parsed.payload, "ps2ps4eu:v2", pgClient, discordClient);
             }

--- a/vehicles.js
+++ b/vehicles.js
@@ -3,7 +3,7 @@
  * @module vehicles
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const {censusRequest, localeNumber, faction} = require('./utils.js');
 const vehicles = require('./static/parsedVehicles.json');
 const {getWeaponName} = require('./character.js');
@@ -120,7 +120,7 @@ module.exports = {
 			throw i18n.__mf({phrase: "{name} has not used the {vehicle}", locale: locale}, 
 				{name: vInfo.charName, vehicle: vehicleName});
 		}
-		let resEmbed = new Discord.MessageEmbed();
+		let resEmbed = new EmbedBuilder();
 
 		resEmbed.setTitle(vInfo.charName);
 		resEmbed.setDescription(vehicleName);
@@ -128,23 +128,25 @@ module.exports = {
 		resEmbed.setColor(faction(vInfo.faction).color);
 		const hoursPlayed = Math.floor(vInfo.playTime/3600);
 		const minutesPlayed = Math.floor(vInfo.playTime/60 - hoursPlayed*60);
-		resEmbed.addField(i18n.__({phrase: "Playtime", locale: locale}), 
-			i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: hoursPlayed, minute: minutesPlayed}), true);
-		resEmbed.addField(i18n.__({phrase: "Score (SPM)", locale: locale}), 
-			`${vInfo.score.toLocaleString(locale)} (${localeNumber(vInfo.score/vInfo.playTime*60, locale)})`, true);
-		resEmbed.addField(i18n.__({phrase: "Weapon Kills", locale: locale}), 
-			vInfo.weaponKills.toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "Road Kills", locale: locale}), 
-			(vInfo.totalKills-vInfo.weaponKills).toLocaleString(locale), true);
-		resEmbed.addField(i18n.__({phrase: "Total KPM", locale: locale}), 
-			localeNumber(vInfo.totalKills/vInfo.playTime*60, locale), true);
-		resEmbed.addField(i18n.__({phrase: "Vehicle Kills (KPM)", locale: locale}), 
-			`${vInfo.vehicleKills.toLocaleString(locale)} (${localeNumber(vInfo.vehicleKills/vInfo.playTime*60, locale)})`, true);
-		resEmbed.addField(i18n.__({phrase: "Deaths", locale: locale}), 
-			vInfo.totalDeaths.toLocaleString(locale), true);
+		resEmbed.addFields([
+			{name: i18n.__({phrase: "Playtime", locale: locale}),
+				value: i18n.__mf({phrase: "{hour}h, {minute}m", locale: locale}, {hour: hoursPlayed, minute: minutesPlayed}), inline: true},
+			{name: i18n.__({phrase: "Score (SPM)", locale: locale}),
+				value: `${vInfo.score.toLocaleString(locale)} (${localeNumber(vInfo.score/vInfo.playTime*60, locale)})`, inline: true},
+			{name: i18n.__({phrase: "Weapon Kills", locale: locale}), 
+				value: vInfo.weaponKills.toLocaleString(locale), inline: true},
+			{name: i18n.__({phrase: "Road Kills", locale: locale}), 
+				value: (vInfo.totalKills-vInfo.weaponKills).toLocaleString(locale), inline: true},
+			{name: i18n.__({phrase: "Total KPM", locale: locale}), 
+				value: localeNumber(vInfo.totalKills/vInfo.playTime*60, locale), inline: true},
+			{name: i18n.__({phrase: "Vehicle Kills (KPM)", locale: locale}), 
+				value: `${vInfo.vehicleKills.toLocaleString(locale)} (${localeNumber(vInfo.vehicleKills/vInfo.playTime*60, locale)})`, inline: true},
+			{name: i18n.__({phrase: "Deaths", locale: locale}), 
+				value: vInfo.totalDeaths.toLocaleString(locale), inline: true}
+		]);
 		if(vInfo.topWeaponID != -1){
 			const topWeaponName = await getWeaponName(vInfo.topWeaponID, platform);
-			resEmbed.addField(i18n.__({phrase: "Top Weapon (kills)", locale: locale}), `${topWeaponName} (${vInfo.topWeaponKills.toLocaleString(locale)})`, true);
+			resEmbed.addFields({name: i18n.__({phrase: "Top Weapon (kills)", locale: locale}), value: `${topWeaponName} (${vInfo.topWeaponKills.toLocaleString(locale)})`, inline: true});
 		}
 
 		return resEmbed;

--- a/weapon.js
+++ b/weapon.js
@@ -3,7 +3,7 @@
  * @module weaponInfo
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const weaponsJSON = require('./static/weapons.json');
 const {badQuery, localeNumber} = require('./utils.js');
 const i18n = require('i18n');
@@ -110,77 +110,79 @@ module.exports = {
 
 		let wInfo = await weaponInfo(name);
 		
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 
 		resEmbed.setTitle(wInfo.name);
 		wInfo.image_id != -1 && resEmbed.setThumbnail('http://census.daybreakgames.com/files/ps2/images/static/'+wInfo.image_id+'.png');
 		
 		if(typeof(wInfo.category) !== 'undefined'){
-			resEmbed.addField(i18n.__({phrase: "Category", locale: locale}), wInfo.category, true);
+			resEmbed.addFields({name: i18n.__({phrase: "Category", locale: locale}), value: wInfo.category, inline: true});
 		}
 
 		if(typeof(wInfo.fireRate) !== 'undefined'){
 			if(wInfo.fireRate != 0 && wInfo.clip != 1){
-				resEmbed.addField(i18n.__({phrase: "Fire Rate", locale: locale}), localeNumber(60*(1000/wInfo.fireRate), locale), true);
+				resEmbed.addFields({name: i18n.__({phrase: "Fire Rate", locale: locale}), value: localeNumber(60*(1000/wInfo.fireRate), locale), inline: true});
 			}
 		}
 		if(typeof(wInfo.heatCapacity) !== 'undefined'){
-			resEmbed.addField(i18n.__({phrase: "Heat Capacity", locale: locale}), wInfo.heatCapacity, true);
-			resEmbed.addField(i18n.__({phrase: "Heat Per Shot", locale: locale}), wInfo.heatPerShot, true);
-			resEmbed.addField(i18n.__({phrase: "Heat Bleed Off", locale: locale}), wInfo.heatBleedOff+"/s", true);
-			resEmbed.addField(i18n.__({phrase: "Recovery Delay", locale: locale}), wInfo.heatRecoveryDelay/1000+" s \n "+(Number(wInfo.overheatPenalty)+Number(wInfo.heatRecoveryDelay))/1000+" s Overheated", true);
+			resEmbed.addFields([
+				{name: i18n.__({phrase: "Heat Capacity", locale: locale}), value: wInfo.heatCapacity, inline: true},
+				{name: i18n.__({phrase: "Heat Per Shot", locale: locale}), value: wInfo.heatPerShot, inline: true},
+				{name: i18n.__({phrase: "Heat Bleed Off", locale: locale}), value: wInfo.heatBleedOff+"/s", inline: true},
+				{name: i18n.__({phrase: "Recovery Delay", locale: locale}), value: wInfo.heatRecoveryDelay/1000+" s \n "+(Number(wInfo.overheatPenalty)+Number(wInfo.heatRecoveryDelay))/1000+" s Overheated", inline: true}
+			]);
 		}
 		else if (typeof(wInfo.clip) !== 'undefined' && wInfo.clip != 1){
 			if(typeof(wInfo.ammo) !== 'undefined' && wInfo.ammo != 1){
-				resEmbed.addField(i18n.__({phrase: "Ammo", locale: locale}), 
-				i18n.__mf({phrase: "{m} magazine", locale: locale}, {m: wInfo.clip})+"\n"+
-				i18n.__mf({phrase: "{c} capacity", locale: locale}, {c: wInfo.ammo}), true);
+				resEmbed.addFields({name: i18n.__({phrase: "Ammo", locale: locale}), 
+				value: i18n.__mf({phrase: "{m} magazine", locale: locale}, {m: wInfo.clip})+"\n"+
+				i18n.__mf({phrase: "{c} capacity", locale: locale}, {c: wInfo.ammo}), inline: true});
 			}
 			else{
-				resEmbed.addField(i18n.__({phrase: "Magazine", locale: locale}), wInfo.clip, true);
+				resEmbed.addFields({name: i18n.__({phrase: "Magazine", locale: locale}), value: wInfo.clip, inline: true});
 			}
 			if(typeof(wInfo.reload) !== 'undefined' && wInfo.reload != 0){
 				if(typeof(wInfo.chamber) !== 'undefined' && wInfo.chamber != 0){
 					const shortReload = localeNumber(wInfo.reload/1000, locale);
 					const longReload = localeNumber(wInfo.reload/1000+wInfo.chamber/1000, locale);
-					resEmbed.addField(i18n.__({phrase: "Reload", locale: locale}), 
-					i18n.__mf({phrase: "{time}s Short", locale: locale}, {time: shortReload})+"\n"+
-					i18n.__mf({phrase: "{time}s Long", locale: locale}, {time: longReload}), true);
+					resEmbed.addFields({name: i18n.__({phrase: "Reload", locale: locale}), 
+					value: i18n.__mf({phrase: "{time}s Short", locale: locale}, {time: shortReload})+"\n"+
+					i18n.__mf({phrase: "{time}s Long", locale: locale}, {time: longReload}), inline: true});
 				}
 				else{
 					// Some weapons with magazines don't have long/short reloads, e.g. P2-120 HEAT
 					const reload = localeNumber(wInfo.reload/1000, locale);
-					resEmbed.addField(i18n.__({phrase: "Reload", locale: locale}), 
-					i18n.__mf({phrase: "{time}s", locale: locale}, {time: reload}), true);
+					resEmbed.addFields({name: i18n.__({phrase: "Reload", locale: locale}), 
+					value: i18n.__mf({phrase: "{time}s", locale: locale}, {time: reload}), inline: true});
 				}
 			}
 		}
 		else if(typeof(wInfo.reload) !== 'undefined' && wInfo.reload != 0){
-			resEmbed.addField(i18n.__({phrase: "Reload", locale: locale}), wInfo.reload/1000+"s", true);
+			resEmbed.addFields({name: i18n.__({phrase: "Reload", locale: locale}), value: wInfo.reload/1000+"s", inline: true});
 		}
 
 		
 
 		if(typeof(wInfo.maxDamage) !== 'undefined'){	
-			resEmbed.addField(i18n.__({phrase: "Damage", locale: locale}), wInfo.maxDamage+" @ "+wInfo.maxDamageRange+"m \n "+wInfo.minDamage+" @ "+wInfo.minDamageRange+"m", true);
+			resEmbed.addFields({name: i18n.__({phrase: "Damage", locale: locale}), value: wInfo.maxDamage+" @ "+wInfo.maxDamageRange+"m \n "+wInfo.minDamage+" @ "+wInfo.minDamageRange+"m", inline: true});
 			if(wInfo.pellets > 1){
-				resEmbed.addField(i18n.__({phrase: "Pellets", locale: locale}), wInfo.pellets, true);
-				resEmbed.addField(i18n.__({phrase: "Pellet Spread", locale: locale}), wInfo.pelletSpread, true);
+				resEmbed.addFields({name: i18n.__({phrase: "Pellets", locale: locale}), value: wInfo.pellets, inline: true});
+				resEmbed.addFields({name: i18n.__({phrase: "Pellet Spread", locale: locale}), value: wInfo.pelletSpread, inline: true});
 			}
 			if(typeof(wInfo.speed) !== 'undefined'){
-				resEmbed.addField(i18n.__({phrase: "Muzzle Velocity", locale: locale}), 
-				i18n.__mf({phrase: "{speed} m/s", locale: locale}, {speed: wInfo.speed}), true);
+				resEmbed.addFields({name: i18n.__({phrase: "Muzzle Velocity", locale: locale}), 
+				value: i18n.__mf({phrase: "{speed} m/s", locale: locale}, {speed: wInfo.speed}), inline: true});
 			}
 		}
 
 		if(typeof(wInfo.indirectDamage) !== 'undefined' && wInfo.directDamage !== 'undefined'){ //checking for damage equality is pretty much just ruling out the Tomoe
-			resEmbed.addField(i18n.__({phrase: "Direct Damage", locale: locale}), wInfo.directDamage, true);
+			resEmbed.addFields({ name: i18n.__({phrase: "Direct Damage", locale: locale}), value: wInfo.directDamage, inline: true});
 			if(wInfo.indirectDamage != 0){
-				resEmbed.addField(i18n.__({phrase: "Indirect Damage", locale: locale}), wInfo.indirectDamage, true);
+				resEmbed.addFields({ name: i18n.__({phrase: "Indirect Damage", locale: locale}), value: wInfo.indirectDamage, inline: true});
 			}
 		}
 		else if(typeof(wInfo.damage) !== 'undefined' && typeof(wInfo.maxDamage) == 'undefined'){
-			resEmbed.addField(i18n.__({phrase: "Damage", locale: locale}), wInfo.damage, true);
+			resEmbed.addFields({ name: i18n.__({phrase: "Damage", locale: locale}), value: wInfo.damage, inline: true});
 		}
 
 		let hipCOFMin = ["?","?","?","?","?","?"];
@@ -190,19 +192,19 @@ module.exports = {
 
 		//Checking for vertical recoil here and below keeps things like med kits from displaying irrelevant stats
 		if(typeof(wInfo.adsCofRecoil) !== 'undefined' && typeof(wInfo.hipCofRecoil) !== 'undefined' && typeof(wInfo.verticalRecoil) !== 'undefined'){ 
-			resEmbed.addField(i18n.__({phrase: "Bloom (hip/ADS)", locale: locale}), wInfo.hipCofRecoil+"/"+wInfo.adsCofRecoil, true);
+			resEmbed.addFields({name: 18n.__({phrase: "Bloom (hip/ADS)", locale: locale}), value: wInfo.hipCofRecoil+"/"+wInfo.adsCofRecoil, inline: true});
 		}
 		else if(typeof(wInfo.hipCofRecoil) !== 'undefined' && typeof(wInfo.verticalRecoil) !== 'undefined'){
-			resEmbed.addField(i18n.__({phrase: "Bloom (hip)", locale: locale}), wInfo.hipCofRecoil, true);
+			resEmbed.addFields({name: 18n.__({phrase: "Bloom (hip)", locale: locale}), value: wInfo.hipCofRecoil, inline: true});
 		}
-		wInfo.verticalRecoil && resEmbed.addField(i18n.__({phrase: "Vertical Recoil", locale: locale}), wInfo.verticalRecoil, true);
-		wInfo.recoilAngleMin && wInfo.recoilAngleMax && resEmbed.addField(i18n.__({phrase: "Recoil Angle (min/max)", locale: locale}), wInfo.recoilAngleMin+"/"+wInfo.recoilAngleMax, true);
-		wInfo.recoilHorizontalMin && wInfo.recoilHorizontalMax && resEmbed.addField(i18n.__({phrase: "Horizontal Recoil (min/max)", locale: locale}), wInfo.recoilHorizontalMin+"/"+wInfo.recoilHorizontalMax, true);
-		wInfo.recoilHorizontalTolerance && resEmbed.addField(i18n.__({phrase: "Horizontal Tolerance", locale: locale}), wInfo.recoilHorizontalTolerance, true);
-		wInfo.firstShotMultiplier && resEmbed.addField(i18n.__({phrase: "First Shot Multiplier", locale: locale}), wInfo.firstShotMultiplier+"x", true);
-		wInfo.fireModes?.length && resEmbed.addField(i18n.__({phrase: "Fire Modes", locale: locale}), `${wInfo.fireModes}`.replace(/,/g, '\n'), true);
-		wInfo.headshotMultiplier && resEmbed.addField(i18n.__({phrase: "Headshot Multiplier", locale: locale}), Number(wInfo.headshotMultiplier)+1+"x", true);
-		wInfo.defZoom && wInfo.defZoom != 1 && resEmbed.addField(i18n.__({phrase: "Iron Sights Zoom", locale: locale}), wInfo.defZoom+"x", true);
+		wInfo.verticalRecoil && resEmbed.addFields({name: i18n.__({phrase: "Vertical Recoil", locale: locale}), value: wInfo.verticalRecoil, inline: true});
+		wInfo.recoilAngleMin && wInfo.recoilAngleMax && resEmbed.addFields({name: i18n.__({phrase: "Recoil Angle (min/max)", locale: locale}), value: wInfo.recoilAngleMin+"/"+wInfo.recoilAngleMax, inline: true});
+		wInfo.recoilHorizontalMin && wInfo.recoilHorizontalMax && resEmbed.addFields({name: i18n.__({phrase: "Horizontal Recoil (min/max)", locale: locale}), value: wInfo.recoilHorizontalMin+"/"+wInfo.recoilHorizontalMax, inline: true});
+		wInfo.recoilHorizontalTolerance && resEmbed.addFields({name: i18n.__({phrase: "Horizontal Tolerance", locale: locale}), value: wInfo.recoilHorizontalTolerance, inline: true});
+		wInfo.firstShotMultiplier && resEmbed.addFields({name: i18n.__({phrase: "First Shot Multiplier", locale: locale}), value: wInfo.firstShotMultiplier+"x", inline: true});
+		wInfo.fireModes?.length && resEmbed.addFields({name: i18n.__({phrase: "Fire Modes", locale: locale}), value: `${wInfo.fireModes}`.replace(/,/g, '\n'), inline: true});
+		wInfo.headshotMultiplier && resEmbed.addFields({name: i18n.__({phrase: "Headshot Multiplier", locale: locale}), value: Number(wInfo.headshotMultiplier)+1+"x", inline: true});
+		wInfo.defZoom && wInfo.defZoom != 1 && resEmbed.addFields({name: i18n.__({phrase: "Iron Sights Zoom", locale: locale}), value: wInfo.defZoom+"x", inline: true});
 
 		if(typeof(wInfo.verticalRecoil) !== 'undefined'){
 			if(typeof(wInfo.standingCofMin) !== 'undefined'){
@@ -232,7 +234,7 @@ module.exports = {
 		}
 			
 		if(typeof(wInfo.adsMoveSpeed) !== 'undefined'){
-			resEmbed.addField(i18n.__({phrase: "ADS Move Speed", locale: locale}), wInfo.adsMoveSpeed, true);
+			resEmbed.addFields({name: 18n.__({phrase: "ADS Move Speed", locale: locale}), value: wInfo.adsMoveSpeed, inline: true});
 			if(typeof(wInfo.standingCofMinADS) !== 'undefined'){
 				adsCOFMin[0] = wInfo.standingCofMinADS;
 				adsCOFMax[0] = wInfo.standingCofMaxADS;
@@ -261,36 +263,44 @@ module.exports = {
 
 		if(CoFUpdated(hipCOFMin) || CoFUpdated(adsCOFMin)){
 			if(standingOnly(hipCOFMin) || standingOnly(adsCOFMin)){
-				resEmbed.addField('\u200b', '\u200b');
+				resEmbed.addFields({name: '\u200b', value: '\u200b'});
 			}
 			else{
-				resEmbed.addField("-------------------", i18n.__({phrase: "*CoF shown Stand/Crouch/Walk/Sprint/Fall/Crouch Walk*", locale: locale}));
+				resEmbed.addFields({name: "-------------------", value: i18n.__({phrase: "*CoF shown Stand/Crouch/Walk/Sprint/Fall/Crouch Walk*", locale: locale})});
 			}
 		}
 
 		if(CoFUpdated(hipCOFMin)){
 			if(standingOnly(hipCOFMin)){
-				resEmbed.addField(i18n.__({phrase: "Hipfire CoF Min", locale: locale}), hipCOFMin[0], true);
-				resEmbed.addField(i18n.__({phrase: "Hipfire CoF Max", locale: locale}), hipCOFMax[0], true);
-				resEmbed.addField('\u200b', '\u200b', true);
+				resEmbed.addFields([
+					{name: i18n.__({phrase: "Hipfire CoF Min", locale: locale}), value: hipCOFMin[0], inline: true},
+					{name: i18n.__({phrase: "Hipfire CoF Max", locale: locale}), value: hipCOFMax[0], inline: true},
+					{name: '\u200b', value: '\u200b', inline: true}
+				]);
 			}
 			else{
-				resEmbed.addField(i18n.__({phrase: "Hipfire CoF Min", locale: locale}), hipCOFMin[0]+"/"+hipCOFMin[1]+"/"+hipCOFMin[2]+"/"+hipCOFMin[3]+"/"+hipCOFMin[4]+"/"+hipCOFMin[5], true);
-				resEmbed.addField(i18n.__({phrase: "Hipfire CoF Max", locale: locale}), hipCOFMax[0]+"/"+hipCOFMax[1]+"/"+hipCOFMax[2]+"/"+hipCOFMax[3]+"/"+hipCOFMax[4]+"/"+hipCOFMax[5], true);
-				resEmbed.addField('\u200b', '\u200b', true);
+				resEmbed.addFields([
+					{name: i18n.__({phrase: "Hipfire CoF Min", locale: locale}), value: hipCOFMin[0]+"/"+hipCOFMin[1]+"/"+hipCOFMin[2]+"/"+hipCOFMin[3]+"/"+hipCOFMin[4]+"/"+hipCOFMin[5], inline: true},
+					{name: i18n.__({phrase: "Hipfire CoF Max", locale: locale}), value: hipCOFMax[0]+"/"+hipCOFMax[1]+"/"+hipCOFMax[2]+"/"+hipCOFMax[3]+"/"+hipCOFMax[4]+"/"+hipCOFMax[5], inline: true},
+					{name: '\u200b', value: '\u200b', inline: true}
+				]);
 			}
 		}
 
 		if(CoFUpdated(adsCOFMin)){
 			if(standingOnly(adsCOFMin)){
-				resEmbed.addField(i18n.__({phrase: "ADS CoF Min", locale: locale}), adsCOFMin[0], true);
-				resEmbed.addField(i18n.__({phrase: "ADS CoF Max", locale: locale}), adsCOFMax[0], true);
-				resEmbed.addField('\u200b', '\u200b', true);
+				resEmbed.addFields([
+					{name: i18n.__({phrase: "ADS CoF Min", locale: locale}), value: adsCOFMin[0], inline: true},
+					{name: i18n.__({phrase: "ADS CoF Max", locale: locale}), value: adsCOFMax[0], inline: true},
+					{name: '\u200b', value: '\u200b', inline: true}
+				]);
 			}
 			else{
-				resEmbed.addField(i18n.__({phrase: "ADS CoF Min", locale: locale}), adsCOFMin[0]+"/"+adsCOFMin[1]+"/"+adsCOFMin[2]+"/"+adsCOFMin[3]+"/"+adsCOFMin[4]+"/"+adsCOFMin[5], true);
-				resEmbed.addField(i18n.__({phrase: "ADS CoF Max", locale: locale}), adsCOFMax[0]+"/"+adsCOFMax[1]+"/"+adsCOFMax[2]+"/"+adsCOFMax[3]+"/"+adsCOFMax[4]+"/"+adsCOFMax[5], true);
-				resEmbed.addField('\u200b', '\u200b', true);
+				resEmbed.addFields([
+					{name: i18n.__({phrase: "ADS CoF Min", locale: locale}), value: adsCOFMin[0]+"/"+adsCOFMin[1]+"/"+adsCOFMin[2]+"/"+adsCOFMin[3]+"/"+adsCOFMin[4]+"/"+adsCOFMin[5], inline: true},
+					{name: i18n.__({phrase: "ADS CoF Max", locale: locale}), value: adsCOFMax[0]+"/"+adsCOFMax[1]+"/"+adsCOFMax[2]+"/"+adsCOFMax[3]+"/"+adsCOFMax[4]+"/"+adsCOFMax[5], inline: true},
+					{name: '\u200b', value: '\u200b', inline: true}
+				]);
 			}
 			
 		}

--- a/weaponSearch.js
+++ b/weaponSearch.js
@@ -3,7 +3,7 @@
  * @module weaponSearch
  */
 
-const Discord = require('discord.js');
+const {MessageEmbed: EmbedBuilder} = require('discord.js');
 const weaponsJSON = require('./static/weapons.json');
 const {badQuery} = require('./utils.js');
 
@@ -37,9 +37,9 @@ module.exports = {
 		if(found.length == 0){
 			throw "No weapons found matching that query";
 		}
-		let resEmbed = new Discord.MessageEmbed();
+		const resEmbed = new EmbedBuilder();
 		resEmbed.setTitle("Weapon search results");
-		resEmbed.addField('\u200b', `${found}`.replace(/,/g, '\n'));
+		resEmbed.addFields({name: '\u200b', value: `${found}`.replace(/,/g, '\n')});
 
 		return resEmbed;
 	}


### PR DESCRIPTION
Major changes are switching `.addField()` to `.addField` and adding in import aliases. `enum` values that couldn't have been swapped over are channel guards and interaction guards.

When `discord.js ` is updated to v14, the import aliases will have to be modified, and any imports that are `require('discord-api-types/v10)` should be changed to `require(discord.js)`.