### PR TITLE
Remove dead code from `messageHandler.js`

### DIFF
--- a/messageHandler.js
+++ b/messageHandler.js
@@ -46,20 +46,4 @@ module.exports = {
         }
         return -1;
     },
-
-    /**
-     * Logs errors where which function the error occured in
-     * @param {discord.Channel} channel - the channel to send the error message to
-     * @param {string} err - the error to send
-     * @param {string} context - the context of the error 
-     */
-    handleError: function(channel, err, context="default"){
-        if(typeof(err) == 'string'){
-            this.send(channel, err, context);
-        }
-        else{
-            console.log(`Error returned from function in context: ${context}`);
-            console.log(err);
-        }
-    }
 }


### PR DESCRIPTION
`handleError()` was originally added in ad6c5bd79669cf0f7cd2d897e0faba857379052c. However with 24f3214eed486523ccf614e6e6b7b8e91628b11a `handleError` was no longer used.