### PR TITLE
Move stats code into `stats.js` file

### DIFF
--- a/main.js
+++ b/main.js
@@ -221,14 +221,7 @@ client.on('interactionCreate', async interaction => {
 
 			case 'stats':
 				await interaction.deferReply(); //Give the bot time to look up the results
-				if(interaction.options.get('weapon')){
-					res = await stats.lookup(options.getString('name').toLowerCase(), options.getString('weapon').toLowerCase(), options.getString('platform') || 'ps2:v2', interaction.locale);
-					await interaction.editReply({embeds:[res]});
-				}
-				else{ //character lookup
-					res = await char.character(interaction.options.getString('name').toLowerCase(), interaction.options.getString('platform') || 'ps2:v2', interaction.locale);
-					await interaction.editReply({embeds:[res[0]], components: res[1]});
-				}
+				stats.execute(interaction, interaction.locale);
 				break;
 
 			case 'outfit':

--- a/stats.js
+++ b/stats.js
@@ -1,6 +1,7 @@
 /**
  * This file implements functions to look up a character's stats with a specific weapon
  * @module stats
+ * @typedef {import('discord.js').Interaction} Interaction
  */
 
 const Discord = require('discord.js');
@@ -8,6 +9,7 @@ const weaponsJSON = require('./static/weapons.json');
 const sanction = require('./static/sanction.json');
 const { badQuery, censusRequest, localeNumber, faction } = require('./utils.js');
 const i18n = require('i18n');
+const { character } = require('./character.js');
 
 /**
  * Get weapon name and id
@@ -289,5 +291,23 @@ module.exports = {
 		return resEmbed;
 	},
 
-	partialMatches: partialMatches
+	partialMatches: partialMatches,
+	/**
+	 * runs the `/stats` command
+	 * @param { Interaction } interaction - command chat interaction
+	 * @param { string } locale - The locale to use for the command
+	 */
+	execute: async function execute(interaction, locale) {
+		const name = interaction.options.getString('name').toLowerCase(); 
+		const platform = interaction.options.getString('platform') || 'ps2:v2';
+		if(interaction.options.get('weapon')){
+			const weapon = interaction.options.getString('weapon').toLowerCase();
+			const res = await this.lookup(name, weapon, platform, locale);
+			await interaction.editReply({embeds:[res]});
+		}
+		else{ //character lookup
+			const [sendEmbed, row] = await character(name, platform, locale);
+			await interaction.editReply({embeds: [sendEmbed], components: row});
+		}
+	}
 }


### PR DESCRIPTION
By having an `execute()` function and moving stats specific code away from `main.js` this makes it easier in the future to remove the giant `switch` in `main.js`