### PR TITLE
Make `partialMatches()` more generic to use

### DIFF
--- a/implant.js
+++ b/implant.js
@@ -1,6 +1,7 @@
 /**
  * Search up implant information
  * @module implant
+ * @typedef {import('discord.js').CommandInteractionOptionResolver} CommandInteractionOptionResolver
  */
 const Discord = require('discord.js');
 const implantsJSON = require('./static/implants.json');
@@ -34,12 +35,14 @@ const implantInfo = async function(name){
 
 /**
  * Search for partial matches of implants
- * @param {string} query - the query to search for
+ * @param { CommandInteractionOptionResolver } options - the query to search for
  * @returns list of possible matches implant
  */
-const partialMatches = async function(query){
+function partialMatches(options) {
+	const query = options.getString('query')
+		.replace(/[“”]/g, '"')
+		.toLowerCase();
 	const matches = [];
-	query = query.replace(/[“”]/g, '"').toLowerCase();
 
 	for(const implant in implantsJSON){
 		if(implant.toLowerCase().includes(query)){
@@ -50,7 +53,7 @@ const partialMatches = async function(query){
 		}
 	}
 
-	return matches
+	return matches;
 }
 
 module.exports = {

--- a/main.js
+++ b/main.js
@@ -645,8 +645,8 @@ client.on('interactionCreate', async interaction => {
 	else if(interaction.isAutocomplete()){
 		try{
 			if(interaction.commandName == 'stats'){
-				const weaponsList = await stats.partialMatches(interaction.options.getString('weapon'));
-				await interaction.respond(weaponsList);
+				const results = stats.partialMatches(interaction.options);
+				await interaction.respond(results);
 			}
 			else if(interaction.commandName == 'weapon'){
 				const results = weapon.partialMatches(interaction.options);

--- a/main.js
+++ b/main.js
@@ -653,8 +653,8 @@ client.on('interactionCreate', async interaction => {
 				await interaction.respond(weaponsList);
 			}
 			else if(interaction.commandName == 'implant'){
-				const implantList = await implant.partialMatches(interaction.options.getString('query'));
-				await interaction.respond(implantList);
+				const results = implant.partialMatches(interaction.options);
+				await interaction.respond(results);
 			}
 			else if(interaction.commandName == 'vehicle'){
 				const vehicleList = await vehicles.partialMatches(interaction.options.getString('vehicle'));

--- a/main.js
+++ b/main.js
@@ -657,8 +657,8 @@ client.on('interactionCreate', async interaction => {
 				await interaction.respond(results);
 			}
 			else if(interaction.commandName == 'vehicle'){
-				const vehicleList = await vehicles.partialMatches(interaction.options.getString('vehicle'));
-				await interaction.respond(vehicleList);
+				const results = vehicles.partialMatches(interaction.options);
+				await interaction.respond(results);
 			}
 		}
 		catch(err){

--- a/main.js
+++ b/main.js
@@ -649,8 +649,8 @@ client.on('interactionCreate', async interaction => {
 				await interaction.respond(weaponsList);
 			}
 			else if(interaction.commandName == 'weapon'){
-				const weaponsList = await weapon.partialMatches(interaction.options.getString('query'));
-				await interaction.respond(weaponsList);
+				const results = weapon.partialMatches(interaction.options);
+				await interaction.respond(results);
 			}
 			else if(interaction.commandName == 'implant'){
 				const results = implant.partialMatches(interaction.options);

--- a/stats.js
+++ b/stats.js
@@ -1,6 +1,7 @@
 /**
  * This file implements functions to look up a character's stats with a specific weapon
  * @module stats
+ * @typedef {import('discord.js').CommandInteractionOptionResolver} CommandInteractionOptionResolver
  */
 
 const Discord = require('discord.js');
@@ -84,16 +85,18 @@ const factions = {
 
 /**
  * Get a list of partial matches for a weapon name
- * @param {string} query - The query to search for 
+ * @param { CommandInteractionOptionResolver } options - The query to search for 
  * @returns a list of  objects with the name and ID of the weapon
  */
-const partialMatches = async function(query){
-	let matches = [];
-	let included = [];
-	query = query.replace(/[“”]/g, '"').toLowerCase();
+function partialMatches(options){
+	const matches = [];
+	const included = [];
+	const query = options.getString('weapon')
+		.replace(/[“”]/g, '"')
+		.toLowerCase();
 
 	for(const id in weaponsJSON){
-		if(weaponsJSON[id].name.toLowerCase().indexOf(query) > -1){
+		if(weaponsJSON[id].name.toLowerCase().includes(query)){
 			if(weaponsJSON[id].faction){
 				matches.push({name: `${weaponsJSON[id].name} (${factions[weaponsJSON[id].faction]} ${weaponsJSON[id].category}) [${id}]`, value: id});
 			}
@@ -111,7 +114,7 @@ const partialMatches = async function(query){
 		if(matches.length >= 25){
 			break;
 		}
-		if(sanction[id].name.toLowerCase().indexOf(query) > -1 && !included.includes(id)){
+		if(sanction[id].name.toLowerCase().includes(query) && !included.includes(id)){
 			matches.push({name: `${sanction[id].name} (${sanction[id].category}) [${id}]`, value: id});
 			included.push(id);
 		}

--- a/vehicles.js
+++ b/vehicles.js
@@ -1,6 +1,7 @@
 /**
  * This file defines functions to look up a player's stats with a given vehicle
  * @module vehicles
+ * @typedef {import('discord.js').CommandInteractionOptionResolver} CommandInteractionOptionResolver
  */
 
 const Discord = require('discord.js');
@@ -152,14 +153,17 @@ module.exports = {
 
 	/**
 	 * Checks if `query` is in any vehicle name
-	 * @param {string} query - query to search for	
+	 * @param { CommandInteractionOptionResolver } options - query to search for	
  	 * @returns a list of vehicle names and ID that contain `query`
 	 */
-	partialMatches: async function(query){
-		let matches = [];
-		query = query.replace(/[“”]/g, '"').toLowerCase();
+	partialMatches: function(options){
+		const query = options.getString('vehicle')
+			.replace(/[“”]/g, '"')
+			.toLowerCase();
+		const matches = [];
+
 		for(const id in vehicles){
-			if(vehicles[id].name.toLowerCase().indexOf(query) > -1){
+			if(vehicles[id].name.toLowerCase().includes(query)){
 				matches.push({name: `${vehicles[id].name} [${id}]`, value: id});
 			}
 			if(matches.length >= 25){

--- a/weapon.js
+++ b/weapon.js
@@ -1,6 +1,7 @@
 /**
  * This file defines functionality to parse weapons.json and return the relevant info
  * @module weaponInfo
+ * @typedef {import('discord.js').CommandInteractionOptionResolver} CommandInteractionOptionResolver
  */
 
 const Discord = require('discord.js');
@@ -71,19 +72,21 @@ const weaponInfo = async function(name){
 
 /**
  * Checks if `query` is in any weapon name. Used to create a list of possible weapons to suggest to the user
- * @param {string} query - query to check
+ * @param { CommandInteractionOptionResolver } options - query to check
  * @returns a list of weapons names that contain `query`
  */
-const partialMatches = async function(query){
-	let matches = [];
-	query = query.replace(/[“”]/g, '"').toLowerCase();
+function partialMatches(options){
+	const matches = [];
+	const query = options.getString('query')
+		.replace(/[“”]/g, '"')
+		.toLowerCase();
 
 	if(query in weaponsJSON){
 		matches.push({name: `${weaponsJSON[query].name} (${weaponsJSON[query].category}) [${query}]`, value: query});
 	}
 
 	for(const id in weaponsJSON){
-		if(weaponsJSON[id].name.toLowerCase().indexOf(query) > -1){
+		if(weaponsJSON[id].name.toLowerCase().includes(query)){
 			matches.push({name: `${weaponsJSON[id].name} (${weaponsJSON[id].category}) [${id}]`, value: id});
 		}
 		if(matches.length >= 25){


### PR DESCRIPTION
Did a little bit of clean up too in each function body to improve readability. By unifying the interface for `partialMatches()` across various commands it should be easier in the future to make the code in `main.js` simpler.