### PR TITLE
Refactor `directives.directives()`

### DIFF
--- a/directives.js
+++ b/directives.js
@@ -50,70 +50,51 @@ module.exports = {
 	 */
 	directives: async function(cName, platform, expanded=false, locale="en-US"){
 		const directiveList = await getDirectiveList(cName.toLowerCase(), platform, locale);
-		let resEmbed = new Discord.MessageEmbed();
-		resEmbed.setTitle(i18n.__mf({phrase: "{name} Directives", locale: locale}, {name: directiveList.name}));
-		let textList = "";
 		let remaining = directiveList.directives.length;
-		if(remaining == 0){
+		if(remaining === 0){
 			throw i18n.__mf({phrase: "{name} has not completed any directives", locale: locale}, {name: directiveList.name});
 		}
-		if(expanded){
-			remaining = 0
-			for(const dir of directiveList.directives){
-				if(dir[0] in directives){
-					textList += `<t:${dir[1]}:d>: ${directives[dir[0]].name}\n`;
-				}
-				else{
-					console.log(`Missing directive id ${dir[0]}`);
-				}
-			}
-			resEmbed.setDescription(textList);
+
+		let max = remaining <= 25 ? 25 : 20; //This is just to avoid returning a list that says "and 1 more", it'll always be at least 5 more
+		if (expanded) {
+			max = remaining;
 		}
-		else{
-			let max = 20;
-			if(remaining <= 25){
-				//This is just to avoid returning a list that says "and 1 more", it'll always be at least 5 more
-				max = 25;
-			}
-			for(const dir of directiveList.directives){
-				if(max == 0){
-					textList += i18n.__mf({phrase: "And {num} more", locale: locale}, {num: remaining});
-					break;
-				}
-				if(dir[0] in directives){
-					textList += `<t:${dir[1]}:d>: ${directives[dir[0]].name}\n`;
-				}
-				else{
-					console.log(`Missing directive id ${dir[0]}`);
-				}
-				remaining -= 1;
-				max -= 1
-			}
-			resEmbed.setDescription(textList);
-		}
-		resEmbed.setColor(faction(directiveList.faction).color)
-		resEmbed.setThumbnail('https://census.daybreakgames.com/files/ps2/images/static/84283.png');
+		const resEmbed = new Discord.MessageEmbed()
+			.setTitle(i18n.__mf({phrase: "{name} Directives", locale: locale}, {name: directiveList.name}))
+			.setColor(faction(directiveList.faction).color)
+			.setThumbnail('https://census.daybreakgames.com/files/ps2/images/static/84283.png');
+		
+		let completedDirectives = '';
+		directiveList.directives
+			.slice(0, max)
+			.forEach(dir => {
+				remaining--;
+				if (dir[0] in directives) completedDirectives += `<t:${dir[1]}:d>: ${directives[dir[0]].name}\n`;
+				else console.log(`Missing directive id ${dir[0]}`);
+			});
+
+		const row = [];
+		if (remaining > 0) {
+			completedDirectives += i18n.__mf({phrase: "And {num} more", locale: locale}, {num: remaining});
+			row[0] = new Discord.MessageActionRow()
+				.addComponents(
+					new Discord.MessageButton()
+						.setCustomId(`directives%${directiveList.name}%${platform}`)
+						.setLabel(i18n.__({phrase: "View all", locale: locale}))
+						.setStyle('PRIMARY')
+				);
+		} 
+			
+		resEmbed.setDescription(completedDirectives);
 		if(platform == 'ps2:v2'){
-			resEmbed.setURL(`https://ps2.fisu.pw/directive/?name=${directiveList[0]}`);
+			resEmbed.setURL(`https://ps2.fisu.pw/directive/?name=${directiveList.name}`);
 		}
 		else if(platform == 'ps2ps4us:v2'){
-			resEmbed.setURL(`https://ps4us.ps2.fisu.pw/directive/?name=${directiveList[0]}`);
+			resEmbed.setURL(`https://ps4us.ps2.fisu.pw/directive/?name=${directiveList.name}`);
 		}
 		else if(platform == 'ps2ps4eu:v2'){
-			resEmbed.setURL(`https://ps4eu.ps2.fisu.pw/directive/?name=${directiveList[0]}`);
+			resEmbed.setURL(`https://ps4eu.ps2.fisu.pw/directive/?name=${directiveList.name}`);
 		}
-		if(remaining > 0){
-			const row = new Discord.MessageActionRow()
-			row.addComponents(
-				new Discord.MessageButton()
-					.setCustomId(`directives%${directiveList.name}%${platform}`)
-					.setLabel(i18n.__({phrase: "View all", locale: locale}))
-					.setStyle('PRIMARY')
-			);
-			return [resEmbed, [row]];
-		}
-		else{
-			return [resEmbed, []];
-		}
+		return [resEmbed, row];
 	}
 }

--- a/directives.js
+++ b/directives.js
@@ -67,10 +67,10 @@ module.exports = {
 		let completedDirectives = '';
 		directiveList.directives
 			.slice(0, max)
-			.forEach(dir => {
+			.forEach(([id, time]) => {
 				remaining--;
-				if (dir[0] in directives) completedDirectives += `<t:${dir[1]}:d>: ${directives[dir[0]].name}\n`;
-				else console.log(`Missing directive id ${dir[0]}`);
+				if (id in directives) completedDirectives += `<t:${time}:d>: ${directives[id].name}\n`;
+				else console.log(`Missing directive id ${id}`);
 			});
 
 		const row = [];


### PR DESCRIPTION
Instead of having two loops that handle iterating over the directives of a character, we can actually combine them into one generic loop. By determining the maximum number of directives, we want to iterate over before determining expanding, the body of the loops become the same.