### PR TITLE
change alert notifications to use Honu

### DIFF
--- a/main.js
+++ b/main.js
@@ -72,6 +72,7 @@ const client = new Discord.Client({intents: intentsList, allowedMentions: {parse
 const token = process.env.token;
 
 let SQLclient = undefined;
+console.log(`starting at ${new Date().toISOString()}`);
 
 client.on('ready', async () => {
 	console.log('Running on '+client.guilds.cache.size+' servers!');
@@ -79,7 +80,9 @@ client.on('ready', async () => {
 	if(runningOnline){
 		SQLclient = new pg.Client({
 			connectionString: process.env.DATABASE_URL,
-			ssl: {rejectUnauthorized: false}
+			ssl: {rejectUnauthorized: false},
+            // if running the DB without a signed cert, disable SSL
+            //ssl: false
 		});
 
 		await SQLclient.connect();


### PR DESCRIPTION
swaps over to using the dropin replacement from Honu

can be reverted back to PS2Alerts with no issues

the one change I made was for population show the actual player count instead of the bracket. I couldn't figure out where PS2Alerts calculates the brackets, so I ended up not worrying about it

example URL: https://wt.honu.pw/api/alerts/dropin/17-51445

example response:
```json
{
  "honuId": 42325,
  "world": 17,
  "censusInstanceId": 51445,
  "instanceId": "17-51445",
  "zone": 8,
  "timeStarted": "2024-03-16T19:03:32Z",
  "timeEnded": null,
  "censusMetagameEventType": 150,
  "metagameEvent": {
    "id": 150,
    "name": "Esamir Superiority",
    "description": "Control territory to lock Esamir",
    "typeID": 9,
    "durationMinutes": 90
  },
  "duration": 5400000,
  "bracket": 4,
  "playerCount": 455,
  "result": {
    "vs": 43,
    "nc": 24,
    "tr": 33,
    "draw": false,
    "victor": null
  }
}
```

accompanies Honu commit: https://github.com/Varunda/honu/commit/aa8e5f051112fb5665e8743495be8ff8f6b0f4f6 (already published)