### PR TITLE
Fix base type for Spral Oasis

### DIFF
--- a/static/bases.json
+++ b/static/bases.json
@@ -1437,7 +1437,7 @@
     "400328": {
         "continent": "8",
         "name": "Spral Oasis",
-        "type": "CTF Construction Outpost"
+        "type": "Construction Outpost"
     },
     "400329": {
         "continent": "344",


### PR DESCRIPTION
[Daybreak API returns](https://census.daybreakgames.com/get/ps2:v2/map_region?map_region_id=18261) a different base type.